### PR TITLE
Assess and implement valuable features

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,10 @@ require (
 )
 
 require (
+	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
+	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=
+github.com/clipperhouse/uax29/v2 v2.2.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -8,6 +10,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
+github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/design/config.go
+++ b/internal/design/config.go
@@ -122,6 +122,7 @@ type Config struct {
 		UseInlineProgress bool   `yaml:"use_inline_progress"`
 		NoSpinner         bool   `yaml:"no_spinner"`
 		SpinnerInterval   int    `yaml:"spinner_interval"`
+		HeaderWidth       int    `yaml:"header_width"` // Visual width of header content (default: 40)
 	} `yaml:"style"`
 
 	Border struct {
@@ -240,6 +241,7 @@ func ASCIIMinimalTheme() *Config {
 	cfg.Style.ShowTimestamps = false
 	cfg.Style.Density = "compact"
 	cfg.Style.NoTimer = false
+	cfg.Style.HeaderWidth = 40
 
 	cfg.Icons.Start = IconStart
 	cfg.Icons.Success = IconSuccess
@@ -306,6 +308,7 @@ func UnicodeVibrantTheme() *Config {
 	cfg.Style.ShowTimestamps = false
 	cfg.Style.Density = "balanced"
 	cfg.Style.NoTimer = false
+	cfg.Style.HeaderWidth = 40
 
 	cfg.Icons.Start = "▶️"
 	cfg.Icons.Success = "✅"

--- a/internal/design/render_test.go
+++ b/internal/design/render_test.go
@@ -249,8 +249,9 @@ func TestTask_RenderSummary_When_IgnoresFoInternalErrors(t *testing.T) {
 
 	cfg := UnicodeVibrantTheme()
 	task := NewTask("test", "", "cmd", nil, cfg)
-	task.AddOutputLine("[fo] Error starting command", TypeError, LineContext{Importance: 5})
-	task.AddOutputLine("Error creating stdout pipe", TypeError, LineContext{Importance: 5})
+	// Use IsInternal flag to mark fo-generated errors
+	task.AddOutputLine("[fo] Error starting command", TypeError, LineContext{Importance: 5, IsInternal: true})
+	task.AddOutputLine("Error creating stdout pipe", TypeError, LineContext{Importance: 5, IsInternal: true})
 
 	output := task.RenderSummary()
 

--- a/mageconsole/console.go
+++ b/mageconsole/console.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/davidkoosis/fo/internal/design"
+	"golang.org/x/term"
 )
 
 type ConsoleConfig struct {
@@ -396,6 +397,12 @@ func (c *Console) executeStreamMode(cmd *exec.Cmd, task *design.Task, cmdDone ch
 		return exitCode, runErr
 	}
 	cmd.Stdout = os.Stdout
+
+	// Connect stdin for interactive input support in stream mode
+	// Check if stdin is a terminal to support interactive commands
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		cmd.Stdin = os.Stdin
+	}
 
 	var waitGroup sync.WaitGroup
 	waitGroup.Add(1)


### PR DESCRIPTION
- Replace rune-count with go-runewidth for accurate visual width calculation of East Asian characters and emojis
- Add stdin passthrough in stream mode for interactive commands
- Clean up internal error detection to use IsInternal flag exclusively
- Make HeaderWidth configurable via .fo.yaml style settings