### PR TITLE
fix: refactor theme configuration to eliminate duplication

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,7 +61,7 @@ const (
 
 // LoadConfig loads the .fo.yaml configuration.
 func LoadConfig() *AppConfig {
-	// Initialize with hardcoded default themes first.
+	// Initialize with default themes from pkg/design (single source of truth).
 	appCfg := &AppConfig{
 		Stream:          false,
 		ShowOutput:      DefaultShowOutput,
@@ -72,11 +72,8 @@ func LoadConfig() *AppConfig {
 		MaxBufferSize:   DefaultMaxBufferSize,
 		MaxLineLength:   DefaultMaxLineLength,
 		ActiveThemeName: DefaultActiveThemeName,
-		Themes: map[string]*design.Config{
-			"unicode_vibrant": design.UnicodeVibrantTheme(), // Hardcoded default
-			"ascii_minimal":   design.ASCIIMinimalTheme(),   // Hardcoded default
-		},
-		Presets: make(map[string]*design.ToolConfig),
+		Themes:          design.DefaultThemes(), // Single source of truth for default themes
+		Presets:         make(map[string]*design.ToolConfig),
 	}
 
 	initialDebug := os.Getenv("FO_DEBUG") != ""

--- a/pkg/design/config.go
+++ b/pkg/design/config.go
@@ -637,6 +637,15 @@ func DeepCopyConfig(original *Config) *Config {
 	return &copied
 }
 
+// DefaultThemes returns a map of all built-in themes.
+// This is the single source of truth for default theme definitions.
+func DefaultThemes() map[string]*Config {
+	return map[string]*Config{
+		"unicode_vibrant": UnicodeVibrantTheme(),
+		"ascii_minimal":   ASCIIMinimalTheme(),
+	}
+}
+
 func ApplyMonochromeDefaults(cfg *Config) {
 	if cfg == nil {
 		return


### PR DESCRIPTION
## Summary

This PR resolves issue #80 by refactoring theme configuration to eliminate duplication between `internal/config` and `pkg/design` packages, establishing `pkg/design` as the single source of truth for theme definitions.

## Problem

Previously, theme definitions were hardcoded in two places:
1. `internal/config/config.go` manually constructed the themes map
2. `pkg/design/config.go` contained the actual theme functions

This created unnecessary coupling and duplication, making it harder to add new themes and violating the single responsibility principle.

## Changes

**pkg/design/config.go:**
- Added `DefaultThemes()` function that returns all built-in themes
- Serves as single source of truth for default theme definitions

**internal/config/config.go:**
- Updated `LoadConfig()` to call `design.DefaultThemes()`
- Removed hardcoded theme initialization
- Simplified implementation

## Benefits

✅ Single source of truth for theme definitions  
✅ Easier to add new themes (only modify pkg/design)  
✅ Reduces code duplication and coupling  
✅ Follows single responsibility principle  
✅ Clearer separation of concerns  
✅ Improved maintainability  

## Testing

- All existing tests pass
- Linter passes with no issues
- Verified themes load correctly with test binary
- Confirmed both themes (unicode_vibrant, ascii_minimal) work as expected

## Closes

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)