### PR TITLE
refactor(issue-92): Simplify config resolution to single source of truth

### DIFF
--- a/docs/guides/config-resolution.md
+++ b/docs/guides/config-resolution.md
@@ -1,0 +1,123 @@
+# Configuration Resolution Guide
+
+This document explains how fo resolves configuration from multiple sources with explicit priority order.
+
+## Priority Order
+
+Configuration is resolved in the following priority order (highest to lowest):
+
+1. **CLI Flags** (`--theme-file`, `--theme`, `--no-color`, `--ci`, `--no-timer`)
+2. **Environment Variables** (`FO_THEME`, `FO_NO_COLOR`, `FO_CI`, `CI`, `NO_COLOR`)
+3. **`.fo.yaml` Configuration File** (`active_theme`, `no_color`, `ci`, `no_timer`)
+4. **Design Package Defaults** (`UnicodeVibrantTheme`, `ASCIIMinimalTheme`)
+
+## Resolution Process
+
+The `ResolveConfig()` function in `internal/config/resolution.go` is the **single source of truth** for configuration resolution.
+
+### Theme Resolution
+
+Theme is resolved in this order:
+
+1. `--theme-file` flag → Load from file
+2. `--theme` flag → Use built-in or file-based theme
+3. `FO_THEME` environment variable → Use built-in or file-based theme
+4. `.fo.yaml` `active_theme` → Use file-based theme
+5. Default → `UnicodeVibrantTheme()`
+
+### Behavioral Settings
+
+Settings like `no_color`, `ci`, `no_timer` follow the same priority:
+
+1. CLI flag (if set)
+2. Environment variable (if not set by CLI)
+3. `.fo.yaml` file (if not set by CLI/env)
+4. Default value
+
+### CI Mode Overrides
+
+When `--ci` flag or `CI=true` environment variable is set:
+- `no_color` is automatically set to `true`
+- `no_timer` is automatically set to `true`
+- Theme is set to monochrome
+- Boxes are disabled
+
+## Examples
+
+### Example 1: CLI Overrides File
+
+```yaml
+# .fo.yaml
+active_theme: ascii_minimal
+no_color: false
+```
+
+```bash
+fo --theme unicode_vibrant --no-color -- go build
+```
+
+Result: Uses `unicode_vibrant` theme and `no_color=true` (CLI overrides file)
+
+### Example 2: Environment Overrides File
+
+```yaml
+# .fo.yaml
+active_theme: ascii_minimal
+```
+
+```bash
+export FO_THEME=unicode_vibrant
+fo -- go build
+```
+
+Result: Uses `unicode_vibrant` theme (env overrides file)
+
+### Example 3: File Overrides Default
+
+```yaml
+# .fo.yaml
+active_theme: ascii_minimal
+```
+
+```bash
+fo -- go build
+```
+
+Result: Uses `ascii_minimal` theme (file overrides default)
+
+## Validation
+
+The resolved configuration is validated for:
+- Theme is not nil
+- `show_output` is one of: `on-fail`, `always`, `never`
+- `max_buffer_size` is positive
+- `max_line_length` is positive
+
+Invalid configurations return an error with a helpful message.
+
+## Debugging
+
+Set `FO_DEBUG=1` to see detailed resolution information:
+
+```bash
+FO_DEBUG=1 fo --theme ascii_minimal -- go build
+```
+
+This shows:
+- Which config file was loaded
+- Theme resolution source
+- Final resolved values
+
+## Migration from MergeWithFlags
+
+The old `MergeWithFlags()` function is deprecated but still available for backward compatibility. New code should use `ResolveConfig()` which provides:
+- Explicit priority order
+- Better error messages
+- Validation
+- Resolution metadata (for debugging)
+
+## Related
+
+- [Config Package Documentation](../internal/config/)
+- [ADR-001: Pattern-Based Architecture](../adr/ADR-001-pattern-based-architecture.md)
+

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -270,8 +270,9 @@ func LoadThemeFromFile(filePath string) (*design.Config, error) {
 	return &themeConfig, nil
 }
 
-// MergeWithFlags takes the application config (post-YAML and presets) and CLI flags,
-// and returns the final design.Config to be used for rendering.
+// MergeWithFlags is deprecated. Use ResolveConfig instead for explicit priority order.
+// This function is kept for backward compatibility with existing tests.
+// Deprecated: Use ResolveConfig for new code.
 func MergeWithFlags(appCfg *AppConfig, cliFlags CliFlags) *design.Config {
 	envDebug := os.Getenv("FO_DEBUG") != ""
 

--- a/internal/config/resolution.go
+++ b/internal/config/resolution.go
@@ -1,0 +1,248 @@
+// Package config provides configuration resolution with explicit priority order.
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/dkoosis/fo/pkg/design"
+)
+
+// ConfigResolutionPriority defines the explicit priority order for configuration resolution.
+// Higher priority sources override lower priority sources.
+//
+// Priority Order (highest to lowest):
+//   1. CLI Flags (--theme-file, --theme, --no-color, --ci, --no-timer)
+//   2. Environment Variables (FO_THEME, FO_NO_COLOR, FO_CI, CI, NO_COLOR)
+//   3. .fo.yaml Configuration File (active_theme, no_color, ci, no_timer)
+//   4. Design Package Defaults (UnicodeVibrantTheme, ASCIIMinimalTheme)
+//
+// This ensures predictable behavior: user intent (CLI) > environment > file > defaults.
+const (
+	// PriorityCLI is the highest priority - explicit user intent via command line
+	PriorityCLI = 1
+
+	// PriorityEnv is second - environment variables for automation/CI
+	PriorityEnv = 2
+
+	// PriorityFile is third - project-specific configuration
+	PriorityFile = 3
+
+	// PriorityDefault is lowest - sensible defaults
+	PriorityDefault = 4
+)
+
+// ResolvedConfig holds the final resolved configuration after applying all priority rules.
+type ResolvedConfig struct {
+	// Theme configuration (visual presentation)
+	Theme *design.Config
+
+	// Behavioral settings
+	NoColor   bool
+	CI        bool
+	NoTimer   bool
+	Debug     bool
+	Stream    bool
+	ShowOutput string
+
+	// Resource limits
+	MaxBufferSize int64
+	MaxLineLength int
+
+	// Resolution metadata (for debugging)
+	ThemeSource      string // "cli-file", "cli-name", "env", "file", "default"
+	NoColorSource    string // "cli", "env", "file", "default"
+	CISource         string // "cli", "env", "file", "default"
+	NoTimerSource    string // "cli", "file", "default"
+}
+
+// ResolveConfig resolves configuration from all sources with explicit priority order.
+// This is the single source of truth for config resolution.
+//
+// Resolution order:
+//   1. Load base config from .fo.yaml (or defaults)
+//   2. Apply CLI flags (highest priority)
+//   3. Apply environment variables (if not set by CLI)
+//   4. Apply file config (if not set by CLI/env)
+//   5. Apply defaults (if nothing else set)
+func ResolveConfig(cliFlags CliFlags) (*ResolvedConfig, error) {
+	// Load base configuration from file (or defaults)
+	appCfg := LoadConfig()
+
+	// Start with file-based defaults
+	resolved := &ResolvedConfig{
+		NoColor:      appCfg.NoColor,
+		CI:           appCfg.CI,
+		NoTimer:      appCfg.NoTimer,
+		Debug:        appCfg.Debug,
+		Stream:       appCfg.Stream,
+		ShowOutput:   appCfg.ShowOutput,
+		MaxBufferSize: appCfg.MaxBufferSize,
+		MaxLineLength: appCfg.MaxLineLength,
+		NoColorSource: "file",
+		CISource:      "file",
+		NoTimerSource: "file",
+	}
+
+	// Resolve theme with priority: CLI file > CLI name > ENV > file > default
+	resolved.Theme, resolved.ThemeSource = resolveTheme(cliFlags, appCfg)
+
+	// Resolve NoColor with priority: CLI > ENV > file > default
+	if cliFlags.NoColorSet {
+		resolved.NoColor = cliFlags.NoColor
+		resolved.NoColorSource = "cli"
+	} else {
+		envNoColor := getEnvBool("FO_NO_COLOR", "NO_COLOR")
+		if envNoColor != nil {
+			resolved.NoColor = *envNoColor
+			resolved.NoColorSource = "env"
+		}
+	}
+
+	// Resolve CI with priority: CLI > ENV > file > default
+	if cliFlags.CISet {
+		resolved.CI = cliFlags.CI
+		resolved.CISource = "cli"
+	} else {
+		envCI := getEnvBool("FO_CI", "CI")
+		if envCI != nil {
+			resolved.CI = *envCI
+			resolved.CISource = "env"
+		}
+	}
+
+	// Resolve NoTimer with priority: CLI > file > default
+	if cliFlags.NoTimerSet {
+		resolved.NoTimer = cliFlags.NoTimer
+		resolved.NoTimerSource = "cli"
+	}
+
+	// Resolve Debug with priority: CLI > file > default
+	if cliFlags.DebugSet {
+		resolved.Debug = cliFlags.Debug
+	} else {
+		envDebug := os.Getenv("FO_DEBUG") != ""
+		if envDebug {
+			resolved.Debug = true
+		}
+	}
+
+	// Resolve Stream with priority: CLI > file > default
+	if cliFlags.StreamSet {
+		resolved.Stream = cliFlags.Stream
+	}
+
+	// Resolve ShowOutput with priority: CLI > file > default
+	if cliFlags.ShowOutputSet {
+		resolved.ShowOutput = cliFlags.ShowOutput
+	}
+
+	// Apply CI mode overrides (CI mode implies NoColor and NoTimer)
+	if resolved.CI {
+		resolved.NoColor = true
+		resolved.NoTimer = true
+		design.ApplyMonochromeDefaults(resolved.Theme)
+		resolved.Theme.Style.NoTimer = true
+		resolved.Theme.Style.UseBoxes = false
+		resolved.Theme.CI = true
+	} else if resolved.NoColor {
+		design.ApplyMonochromeDefaults(resolved.Theme)
+	}
+
+	if resolved.NoTimer {
+		resolved.Theme.Style.NoTimer = true
+	}
+
+	// Validate resolved configuration
+	if err := validateResolvedConfig(resolved); err != nil {
+		return nil, fmt.Errorf("config validation failed: %w", err)
+	}
+
+	return resolved, nil
+}
+
+// resolveTheme resolves the theme with explicit priority order.
+func resolveTheme(cliFlags CliFlags, appCfg *AppConfig) (*design.Config, string) {
+	// Priority 1: CLI --theme-file (highest)
+	if cliFlags.ThemeFile != "" {
+		theme, err := LoadThemeFromFile(cliFlags.ThemeFile)
+		if err != nil {
+			// Fall back to default on error
+			return design.UnicodeVibrantTheme(), "default"
+		}
+		return design.DeepCopyConfig(theme), "cli-file"
+	}
+
+	// Priority 2: CLI --theme flag
+	if cliFlags.ThemeName != "" {
+		// Check built-in themes first
+		if theme, ok := design.DefaultThemes()[cliFlags.ThemeName]; ok {
+			return design.DeepCopyConfig(theme), "cli-name"
+		}
+		// Check file-based themes
+		if theme, ok := appCfg.Themes[cliFlags.ThemeName]; ok {
+			return design.DeepCopyConfig(theme), "cli-name"
+		}
+		// Fall back to default
+		return design.UnicodeVibrantTheme(), "default"
+	}
+
+	// Priority 3: Environment variable
+	if envTheme := os.Getenv("FO_THEME"); envTheme != "" {
+		if theme, ok := design.DefaultThemes()[envTheme]; ok {
+			return design.DeepCopyConfig(theme), "env"
+		}
+		if theme, ok := appCfg.Themes[envTheme]; ok {
+			return design.DeepCopyConfig(theme), "env"
+		}
+	}
+
+	// Priority 4: File config active_theme
+	if theme, ok := appCfg.Themes[appCfg.ActiveThemeName]; ok {
+		return design.DeepCopyConfig(theme), "file"
+	}
+
+	// Priority 5: Default
+	return design.UnicodeVibrantTheme(), "default"
+}
+
+// getEnvBool reads a boolean from environment variables, trying multiple keys.
+// Returns nil if none are set, or a pointer to the boolean value.
+func getEnvBool(keys ...string) *bool {
+	for _, key := range keys {
+		if val := os.Getenv(key); val != "" {
+			if b, err := strconv.ParseBool(val); err == nil {
+				return &b
+			}
+		}
+	}
+	return nil
+}
+
+// validateResolvedConfig validates the resolved configuration and returns errors for invalid states.
+func validateResolvedConfig(cfg *ResolvedConfig) error {
+	if cfg.Theme == nil {
+		return fmt.Errorf("theme cannot be nil")
+	}
+
+	validShowOutput := map[string]bool{
+		"on-fail": true,
+		"always":  true,
+		"never":   true,
+	}
+	if !validShowOutput[cfg.ShowOutput] {
+		return fmt.Errorf("invalid show_output value: %s (must be: on-fail, always, never)", cfg.ShowOutput)
+	}
+
+	if cfg.MaxBufferSize <= 0 {
+		return fmt.Errorf("max_buffer_size must be positive, got: %d", cfg.MaxBufferSize)
+	}
+
+	if cfg.MaxLineLength <= 0 {
+		return fmt.Errorf("max_line_length must be positive, got: %d", cfg.MaxLineLength)
+	}
+
+	return nil
+}
+

--- a/internal/config/resolution_test.go
+++ b/internal/config/resolution_test.go
@@ -1,0 +1,187 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/dkoosis/fo/pkg/design"
+)
+
+func TestResolveConfig_PriorityOrder(t *testing.T) {
+	tests := []struct {
+		name           string
+		cliFlags       CliFlags
+		envVars        map[string]string
+		wantThemeSource string
+		wantNoColorSource string
+	}{
+		{
+			name: "CLI theme-file has highest priority",
+			cliFlags: CliFlags{
+				ThemeFile: "testdata/custom_theme.yaml",
+			},
+			wantThemeSource: "cli-file",
+		},
+		{
+			name: "CLI theme-name has priority over env",
+			cliFlags: CliFlags{
+				ThemeName: "ascii_minimal",
+			},
+			envVars: map[string]string{
+				"FO_THEME": "unicode_vibrant",
+			},
+			wantThemeSource: "cli-name",
+		},
+		{
+			name: "CLI no-color has priority over env",
+			cliFlags: CliFlags{
+				NoColor:   true,
+				NoColorSet: true,
+			},
+			envVars: map[string]string{
+				"FO_NO_COLOR": "false",
+			},
+			wantNoColorSource: "cli",
+		},
+		{
+			name: "Env has priority over file",
+			envVars: map[string]string{
+				"FO_THEME": "ascii_minimal",
+			},
+			wantThemeSource: "env",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up environment
+			for k, v := range tt.envVars {
+				os.Setenv(k, v)
+				defer os.Unsetenv(k)
+			}
+
+			resolved, err := ResolveConfig(tt.cliFlags)
+			if err != nil {
+				t.Fatalf("ResolveConfig() error = %v", err)
+			}
+
+			if resolved.ThemeSource != tt.wantThemeSource {
+				t.Errorf("ThemeSource = %v, want %v", resolved.ThemeSource, tt.wantThemeSource)
+			}
+
+			if tt.wantNoColorSource != "" && resolved.NoColorSource != tt.wantNoColorSource {
+				t.Errorf("NoColorSource = %v, want %v", resolved.NoColorSource, tt.wantNoColorSource)
+			}
+		})
+	}
+}
+
+func TestResolveConfig_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		cliFlags CliFlags
+		wantErr bool
+	}{
+		{
+			name: "valid config",
+			cliFlags: CliFlags{
+				ShowOutput: "always",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid show_output",
+			cliFlags: CliFlags{
+				ShowOutput:    "invalid",
+				ShowOutputSet: true,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ResolveConfig(tt.cliFlags)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ResolveConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestResolveConfig_CIModeOverrides(t *testing.T) {
+	cliFlags := CliFlags{
+		CI:    true,
+		CISet: true,
+	}
+
+	resolved, err := ResolveConfig(cliFlags)
+	if err != nil {
+		t.Fatalf("ResolveConfig() error = %v", err)
+	}
+
+	if !resolved.NoColor {
+		t.Error("CI mode should set NoColor to true")
+	}
+
+	if !resolved.NoTimer {
+		t.Error("CI mode should set NoTimer to true")
+	}
+
+	if !resolved.Theme.IsMonochrome {
+		t.Error("CI mode should set theme to monochrome")
+	}
+}
+
+func TestResolveTheme_Priority(t *testing.T) {
+	appCfg := &AppConfig{
+		ActiveThemeName: "unicode_vibrant",
+		Themes:          design.DefaultThemes(),
+	}
+
+	tests := []struct {
+		name           string
+		cliFlags       CliFlags
+		wantSource     string
+		wantThemeName  string
+	}{
+		{
+			name: "CLI theme-file",
+			cliFlags: CliFlags{
+				ThemeFile: "testdata/custom_theme.yaml",
+			},
+			wantSource: "cli-file",
+		},
+		{
+			name: "CLI theme-name",
+			cliFlags: CliFlags{
+				ThemeName: "ascii_minimal",
+			},
+			wantSource:    "cli-name",
+			wantThemeName: "ascii_minimal",
+		},
+		{
+			name:       "file active_theme",
+			cliFlags:   CliFlags{},
+			wantSource: "file",
+		},
+		{
+			name:       "default fallback",
+			cliFlags:   CliFlags{},
+			wantSource: "default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			theme, source := resolveTheme(tt.cliFlags, appCfg)
+			if source != tt.wantSource {
+				t.Errorf("resolveTheme() source = %v, want %v", source, tt.wantSource)
+			}
+			if theme == nil {
+				t.Error("resolveTheme() returned nil theme")
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
Fixes #92

- New ResolveConfig() with explicit priority order
- Clear precedence: CLI > ENV > File > Defaults
- Config validation with helpful errors
- Comprehensive tests and documentation