### PR TITLE
feat(issue-96): Add --profile mode for performance observability

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -305,6 +305,9 @@ func parseGlobalFlags() (config.CliFlags, bool) {
 		"Force specific visualization pattern (test-table, sparkline, leaderboard, inventory, summary, comparison).")
 	flag.StringVar(&cliFlags.Format, "format", "text",
 		"Output format: 'text' (default) or 'json' (structured output for AI/automation).")
+	flag.BoolVar(&cliFlags.Profile, "profile", false, "Enable performance profiling.")
+	flag.StringVar(&cliFlags.ProfileOutput, "profile-output", "stderr",
+		"Profile output destination: 'stderr' (default) or file path.")
 	flag.BoolVar(&cliFlags.NoTimer, "no-timer", false, "Disable showing the duration.")
 
 	var maxBufferSizeMB int

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,8 @@ type CliFlags struct {
 	ShowOutput    string
 	Pattern       string // Manual pattern selection (e.g., "test-table", "sparkline", "leaderboard")
 	Format        string // Output format: "text" (default) or "json"
+	Profile       bool   // Enable performance profiling
+	ProfileOutput string // Profile output destination: "stderr" or file path
 	NoTimer       bool
 	NoColor       bool
 	CI            bool

--- a/mageconsole/profile.go
+++ b/mageconsole/profile.go
@@ -1,0 +1,114 @@
+package mageconsole
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// ProfileData tracks performance metrics for each pipeline stage.
+type ProfileData struct {
+	Stage           string        `json:"stage"`
+	Duration        time.Duration `json:"duration"`
+	DurationMs      int64         `json:"duration_ms"`
+	PatternMatches  int           `json:"pattern_matches,omitempty"`
+	PatternSuccess  int           `json:"pattern_success,omitempty"`
+	BufferSize      int64         `json:"buffer_size,omitempty"`
+	LineCount       int           `json:"line_count,omitempty"`
+	MemoryAlloc     int64         `json:"memory_alloc,omitempty"`
+}
+
+// Profiler tracks performance metrics throughout command execution.
+type Profiler struct {
+	enabled   bool
+	startTime time.Time
+	stages    []ProfileData
+	output    string // "stderr" or file path
+}
+
+// NewProfiler creates a new profiler instance.
+func NewProfiler(enabled bool, output string) *Profiler {
+	return &Profiler{
+		enabled:   enabled,
+		startTime: time.Now(),
+		stages:    make([]ProfileData, 0),
+		output:    output,
+	}
+}
+
+// StartStage marks the start of a performance stage.
+func (p *Profiler) StartStage(name string) time.Time {
+	if !p.enabled {
+		return time.Now()
+	}
+	return time.Now()
+}
+
+// EndStage records the duration of a performance stage.
+func (p *Profiler) EndStage(name string, start time.Time, metrics map[string]interface{}) {
+	if !p.enabled {
+		return
+	}
+
+	duration := time.Since(start)
+	stage := ProfileData{
+		Stage:      name,
+		Duration:   duration,
+		DurationMs: duration.Milliseconds(),
+	}
+
+	// Extract optional metrics
+	if matches, ok := metrics["pattern_matches"].(int); ok {
+		stage.PatternMatches = matches
+	}
+	if success, ok := metrics["pattern_success"].(int); ok {
+		stage.PatternSuccess = success
+	}
+	if bufferSize, ok := metrics["buffer_size"].(int64); ok {
+		stage.BufferSize = bufferSize
+	}
+	if lineCount, ok := metrics["line_count"].(int); ok {
+		stage.LineCount = lineCount
+	}
+	if memAlloc, ok := metrics["memory_alloc"].(int64); ok {
+		stage.MemoryAlloc = memAlloc
+	}
+
+	p.stages = append(p.stages, stage)
+}
+
+// Write outputs the profile data to the configured destination.
+func (p *Profiler) Write() error {
+	if !p.enabled || len(p.stages) == 0 {
+		return nil
+	}
+
+	totalDuration := time.Since(p.startTime)
+	output := fmt.Sprintf("# fo Performance Profile\n")
+	output += fmt.Sprintf("Total Duration: %s (%d ms)\n\n", totalDuration, totalDuration.Milliseconds())
+	output += fmt.Sprintf("Stage\tDuration\tDuration(ms)\tMatches\tSuccess\tBuffer\tLines\tMemory\n")
+	output += fmt.Sprintf("-----\t--------\t------------\t-------\t-------\t------\t-----\t------\n")
+
+	for _, stage := range p.stages {
+		output += fmt.Sprintf("%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\n",
+			stage.Stage,
+			stage.Duration,
+			stage.DurationMs,
+			stage.PatternMatches,
+			stage.PatternSuccess,
+			stage.BufferSize,
+			stage.LineCount,
+			stage.MemoryAlloc,
+		)
+	}
+
+	if p.output == "stderr" || p.output == "" {
+		fmt.Fprintf(os.Stderr, "\n%s\n", output)
+	} else {
+		// Write to file
+		return os.WriteFile(p.output, []byte(output), 0644)
+	}
+
+	return nil
+}
+


### PR DESCRIPTION
Fixes #96

- Added --profile and --profile-output flags
- Performance tracking for capture and process stages
- Tab-separated output format
- Metrics: duration, buffer size, line count