### PR TITLE
Fix section content padding and add section rendering tests

### DIFF
--- a/fo/console.go
+++ b/fo/console.go
@@ -476,19 +476,21 @@ func (c *Console) PrintSectionContentLine(content ContentLine) {
 		sb.WriteString(reset)
 	}
 
-	// Calculate padding: icon (if present) + space + text
+	// Calculate padding: left padding + icon (if present) + space + text + right padding
 	iconWidth := 0
 	if content.Icon != "" {
 		iconWidth = runewidth.StringWidth(content.Icon) + 1 // Icon + space
 	}
 	textWidth := runewidth.StringWidth(stripANSICodes(content.Text))
 	totalContentWidth := iconWidth + textWidth
-	padding := box.TotalWidth - totalContentWidth - box.RightPadding
-	if padding < 0 {
-		padding = 0
+
+	minRightPadding := box.RightPadding
+	dynamicPadding := (box.TotalWidth - 2) - box.LeftPadding - totalContentWidth - minRightPadding
+	if dynamicPadding < 0 {
+		dynamicPadding = 0
 	}
 
-	sb.WriteString(strings.Repeat(" ", padding))
+	sb.WriteString(strings.Repeat(" ", minRightPadding+dynamicPadding))
 	sb.WriteString(box.BorderColor)
 	sb.WriteString(box.BorderChars.Vertical)
 	sb.WriteString(reset)

--- a/fo/section_render_test.go
+++ b/fo/section_render_test.go
@@ -1,0 +1,94 @@
+package fo
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/mattn/go-runewidth"
+)
+
+func TestConsole_RendersAlignedSectionContentLine_When_IconAndTextProvided(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	console := NewConsole(ConsoleConfig{Out: &buf})
+
+	icon := "✓"
+	text := "Build complete"
+
+	console.PrintSectionContentLine(ContentLine{
+		Icon:      icon,
+		IconColor: console.designConf.GetColor("Success"),
+		Text:      text,
+	})
+
+	output := strings.TrimSuffix(buf.String(), "\n")
+	lines := strings.Split(output, "\n")
+	if len(lines) == 0 {
+		t.Fatalf("expected at least one rendered line, got %d", len(lines))
+	}
+
+	line := lines[0]
+	stripped := stripANSICodes(line)
+	box := console.calculateBoxLayout()
+
+	if got, want := runewidth.StringWidth(stripped), box.TotalWidth; got != want {
+		t.Fatalf("rendered line width mismatch: got %d, want %d", got, want)
+	}
+
+	expectedSegment := icon + " " + text
+	if !strings.Contains(stripped, expectedSegment) {
+		t.Fatalf("expected rendered line to contain %q, got %q", expectedSegment, stripped)
+	}
+
+	iconIndex := -1
+	for idx, r := range []rune(stripped) {
+		if string(r) == icon {
+			iconIndex = idx
+			break
+		}
+	}
+	if iconIndex < 0 {
+		t.Fatalf("icon %q not found in rendered line: %q", icon, stripped)
+	}
+
+	if got, want := iconIndex, 1+box.LeftPadding; got != want {
+		t.Fatalf("icon position mismatch: got %d, want %d", got, want)
+	}
+}
+
+func TestConsole_PreservesSectionWidth_When_TextFillsContentArea(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	console := NewConsole(ConsoleConfig{Out: &buf})
+	box := console.calculateBoxLayout()
+
+	icon := "✓"
+	iconWidth := runewidth.StringWidth(icon) + 1 // icon + trailing space
+	availableTextWidth := (box.TotalWidth - 2) - box.LeftPadding - box.RightPadding - iconWidth
+	if availableTextWidth <= 0 {
+		t.Fatalf("unexpected non-positive available text width: %d", availableTextWidth)
+	}
+
+	text := strings.Repeat("X", availableTextWidth)
+	console.PrintSectionContentLine(ContentLine{Icon: icon, Text: text})
+
+	output := strings.TrimSuffix(buf.String(), "\n")
+	lines := strings.Split(output, "\n")
+	if len(lines) == 0 {
+		t.Fatalf("expected at least one rendered line, got %d", len(lines))
+	}
+
+	line := lines[0]
+	stripped := stripANSICodes(line)
+
+	if got, want := runewidth.StringWidth(stripped), box.TotalWidth; got != want {
+		t.Fatalf("rendered line width mismatch: got %d, want %d", got, want)
+	}
+
+	if !strings.HasSuffix(stripped, box.BorderChars.Vertical) {
+		t.Fatalf("expected rendered line to end with border %q, got %q", box.BorderChars.Vertical, stripped)
+	}
+}


### PR DESCRIPTION
## Summary
- fix section content line padding to respect both left and right spacing
- add tests to ensure section content lines stay aligned and within the expected width

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925f93a0e54832580647cf44aef1a93)