### PR TITLE
Add tests for dashboard parser edge cases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=

--- a/pkg/dashboard/parser_behavior_test.go
+++ b/pkg/dashboard/parser_behavior_test.go
@@ -1,0 +1,109 @@
+package dashboard_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dkoosis/fo/pkg/dashboard"
+)
+
+func TestParseManifest_ReturnsError_When_LineIsMalformed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "missing colon delimiter",
+			input: "build",
+		},
+		{
+			name:  "empty command segment",
+			input: "build :",
+		},
+		{
+			name:  "empty task name",
+			input: ": go test ./...",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := dashboard.ParseManifest(strings.NewReader(tt.input))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestParseManifest_AssignsTasksGroup_When_NoGroupHeaderPresent(t *testing.T) {
+	t.Parallel()
+
+	specs, err := dashboard.ParseManifest(strings.NewReader("format: gofmt -w ."))
+	require.NoError(t, err)
+
+	if diff := cmp.Diff([]dashboard.TaskSpec{{Group: "Tasks", Name: "format", Command: "gofmt -w ."}}, specs); diff != "" {
+		t.Fatalf("unexpected manifest parse (-want +got):\n%s", diff)
+	}
+}
+
+func TestParseTaskFlag_ReturnsError_When_CommandOrNameMissing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		flag string
+	}{
+		{
+			name: "missing command delimiter",
+			flag: "group/name",
+		},
+		{
+			name: "empty command content",
+			flag: "group/name:  ",
+		},
+		{
+			name: "missing task name in grouped flag",
+			flag: "group/: go test ./...",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := dashboard.ParseTaskFlag(tt.flag)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestParseTaskFlag_ParsesComponents_When_GroupPrefixProvided(t *testing.T) {
+	t.Parallel()
+
+	spec, err := dashboard.ParseTaskFlag("Quality/lint: golangci-lint run")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Quality", spec.Group)
+	assert.Equal(t, "lint", spec.Name)
+	assert.Equal(t, "golangci-lint run", spec.Command)
+}
+
+func TestParseTaskFlag_UsesDefaultGroup_When_GroupPrefixMissing(t *testing.T) {
+	t.Parallel()
+
+	spec, err := dashboard.ParseTaskFlag("test: go test ./...")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Tasks", spec.Group)
+	assert.Equal(t, "test", spec.Name)
+	assert.Equal(t, "go test ./...", spec.Command)
+}


### PR DESCRIPTION
## Summary
- add ADR-008-style tests covering dashboard manifest parsing error cases and default grouping
- add table-driven ParseTaskFlag tests for invalid flags and default group behavior
- include go-cmp dependency for struct diff assertions

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694007c6497483258665429b7214c3e3)