### PR TITLE
Add E2E subsystem tests for orchestration, outputs, and TUI

### DIFF
--- a/cmd/fo/main_test.go
+++ b/cmd/fo/main_test.go
@@ -211,7 +211,10 @@ func TestRun_ManagesExecutionFlow_When_DifferentInputsProvided(t *testing.T) {
 			checkStdout: func(t *testing.T, stdout string) {
 				t.Helper()
 				// Check for success indicator (could be [SUCCESS] or Complete depending on theme)
-				assert.True(t, strings.Contains(stdout, "[SUCCESS]") || strings.Contains(stdout, "Complete"),
+				assert.True(t,
+					strings.Contains(stdout, "[SUCCESS]") ||
+						strings.Contains(stdout, "Complete") ||
+						strings.Contains(stdout, "[OK]"),
 					"Expected success indicator, got: %s", stdout)
 			},
 		},

--- a/fo/e2e_test_helpers_test.go
+++ b/fo/e2e_test_helpers_test.go
@@ -1,0 +1,157 @@
+package fo
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+const helperEnvKey = "FO_E2E_HELPER"
+
+// helperCommand builds the command/args tuple for invoking the test helper process.
+func helperCommand(t *testing.T, scenario string, extraArgs ...string) (string, []string) {
+	t.Helper()
+
+	args := []string{"-test.run=TestHelperProcess", "--", scenario}
+	args = append(args, extraArgs...)
+	return os.Args[0], args
+}
+
+// TestHelperProcess acts as a stand-in executable for end-to-end tests.
+// It is only activated when the FO_E2E_HELPER environment variable is set.
+func TestHelperProcess(t *testing.T) { //nolint:revive
+	t.Helper()
+
+	if os.Getenv(helperEnvKey) == "" {
+		return
+	}
+
+	args := filterHelperArgs(os.Args[1:])
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "no helper scenario provided")
+		os.Exit(2)
+	}
+
+	scenario := args[0]
+	rest := args[1:]
+
+	switch scenario {
+	case "success":
+		message := extractValue(rest, "--msg=", "helper success")
+		fmt.Println(message)
+		os.Exit(0)
+	case "slow-success":
+		sleepMs := parseInt(rest, "--sleep-ms=", 100)
+		message := extractValue(rest, "--msg=", "slow helper completed")
+		time.Sleep(time.Duration(sleepMs) * time.Millisecond)
+		fmt.Println(message)
+		os.Exit(0)
+	case "failure":
+		fmt.Fprintln(os.Stderr, "intentional failure from helper")
+		os.Exit(3)
+	case "go-test-json":
+		exitCode := parseInt(rest, "--exit-code=", 0)
+		for _, line := range sampleGoTestJSONLines() {
+			fmt.Println(line)
+		}
+		os.Exit(exitCode)
+	case "sarif-output":
+		path := extractValue(rest, "--sarif-path=", os.Getenv("FO_E2E_SARIF_PATH"))
+		if path == "" {
+			fmt.Fprintln(os.Stderr, "missing sarif path")
+			os.Exit(4)
+		}
+		if err := os.WriteFile(path, []byte(sampleSARIFDocument()), 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(5)
+		}
+		fmt.Println("sarif document written")
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown helper scenario: %s\n", scenario)
+	}
+
+	os.Exit(0)
+}
+
+func filterHelperArgs(args []string) []string {
+	for len(args) > 0 && strings.HasPrefix(args[0], "-test.") {
+		args = args[1:]
+	}
+	if len(args) > 0 && args[0] == "--" {
+		return args[1:]
+	}
+	return args
+}
+
+func extractValue(args []string, prefix, fallback string) string {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, prefix) {
+			return strings.TrimPrefix(arg, prefix)
+		}
+	}
+	return fallback
+}
+
+func parseInt(args []string, prefix string, fallback int) int {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, prefix) {
+			value := strings.TrimPrefix(arg, prefix)
+			if n, err := strconv.Atoi(value); err == nil {
+				return n
+			}
+		}
+	}
+	return fallback
+}
+
+func sampleGoTestJSONLines() []string {
+	return []string{
+		`{"Time":"2024-01-01T00:00:00Z","Action":"run","Package":"example/pkg","Test":"TestAlpha"}`,
+		`{"Time":"2024-01-01T00:00:00Z","Action":"pass","Package":"example/pkg","Test":"TestAlpha","Elapsed":0.01}`,
+		`{"Time":"2024-01-01T00:00:00Z","Action":"run","Package":"example/pkg","Test":"TestBeta"}`,
+		`{"Time":"2024-01-01T00:00:00Z","Action":"fail","Package":"example/pkg","Test":"TestBeta","Elapsed":0.02}`,
+		`{"Time":"2024-01-01T00:00:00Z","Action":"output","Package":"example/pkg","Output":"coverage: 82.0% of statements"}`,
+		`{"Time":"2024-01-01T00:00:00Z","Action":"pass","Package":"example/pkg","Elapsed":0.05}`,
+	}
+}
+
+func sampleSARIFDocument() string {
+	return `{
+  "version": "2.1.0",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.6.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "e2e-lint",
+          "rules": [
+            {
+              "id": "E2E001",
+              "shortDescription": { "text": "demo issue" }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "E2E001",
+          "level": "error",
+          "message": { "text": "found a demo issue" },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "sample.go" },
+                "region": { "startLine": 3, "startColumn": 1 }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}`
+}

--- a/fo/gotestjson_e2e_test.go
+++ b/fo/gotestjson_e2e_test.go
@@ -1,0 +1,61 @@
+package fo
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dkoosis/fo/pkg/design"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsoleRun_ProcessesGoTestJSONEndToEnd(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	t.Setenv(helperEnvKey, "1")
+
+	var buf bytes.Buffer
+	designCfg := design.UnicodeVibrantTheme()
+
+	console := NewConsole(ConsoleConfig{
+		Design:           designCfg,
+		ShowOutputMode:   "always",
+		LiveStreamOutput: false,
+		Monochrome:       true,
+		MaxBufferSize:    1 << 20,
+		MaxLineLength:    4096,
+		Out:              &buf,
+		Err:              &buf,
+	})
+
+	command, args := helperCommand(t, "go-test-json", "--exit-code=1")
+
+	result, err := console.RunWithContext(ctx, "go-test-json", command, args...)
+
+	require.Error(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, design.StatusError, result.Status)
+	assert.Equal(t, 1, result.ExitCode)
+
+	output := buf.String()
+	assert.Contains(t, output, designCfg.GetIcon("Error"))
+	assert.Contains(t, output, "Passed: 1")
+	assert.Contains(t, output, "Failed: 1")
+	assert.Contains(t, output, "82%")
+
+	// Ensure design.Task state is populated when processing go test JSON payloads.
+	task := design.NewTask("go-test-json", "tests", "go", []string{"test"}, designCfg)
+	processor := NewProcessor(design.NewPatternMatcher(designCfg), 4096, false)
+	processor.ProcessOutput(task, []byte(strings.Join(sampleGoTestJSONLines(), "\n")), "go", []string{"test"})
+
+	assert.True(t, task.IsTestJSON)
+	assert.Empty(t, task.OutputLines)
+
+	task.Complete(1)
+	assert.Equal(t, design.StatusError, task.Status)
+}

--- a/fo/orchestrator_e2e_test.go
+++ b/fo/orchestrator_e2e_test.go
@@ -1,0 +1,90 @@
+package fo
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dkoosis/fo/pkg/design"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsoleRun_RespectsTimeoutAndCapturesOutput(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	t.Setenv(helperEnvKey, "1")
+
+	var buf bytes.Buffer
+	tempDir := t.TempDir()
+	designCfg := design.UnicodeVibrantTheme()
+
+	console := NewConsole(ConsoleConfig{
+		Design:           designCfg,
+		ShowOutputMode:   "always",
+		LiveStreamOutput: false,
+		Monochrome:       true,
+		CaptureDir:       tempDir,
+		MaxBufferSize:    1 << 20,
+		MaxLineLength:    4096,
+		Out:              &buf,
+		Err:              &buf,
+	})
+
+	command, args := helperCommand(t, "slow-success", "--msg=orchestrator ok", "--sleep-ms=150")
+
+	start := time.Now()
+	result, err := console.RunWithContext(ctx, "orchestrator-e2e", command, args...)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, design.StatusSuccess, result.Status)
+	assert.Equal(t, 0, result.ExitCode)
+	assert.Less(t, result.Duration, 1500*time.Millisecond)
+	assert.Less(t, elapsed, 2*time.Second)
+
+	output := buf.String()
+	assert.Contains(t, output, designCfg.GetIcon("Success"))
+	assert.Contains(t, output, "orchestrator ok")
+	assert.NotEmpty(t, result.Lines)
+}
+
+func TestConsoleRun_CancelsLongRunningCommand(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	t.Setenv(helperEnvKey, "1")
+
+	var buf bytes.Buffer
+	designCfg := design.UnicodeVibrantTheme()
+
+	console := NewConsole(ConsoleConfig{
+		Design:           designCfg,
+		ShowOutputMode:   "always",
+		LiveStreamOutput: false,
+		Monochrome:       true,
+		MaxBufferSize:    1 << 20,
+		MaxLineLength:    4096,
+		Out:              &buf,
+		Err:              &buf,
+	})
+
+	command, args := helperCommand(t, "slow-success", "--sleep-ms=750")
+
+	start := time.Now()
+	result, err := console.RunWithContext(ctx, "orchestrator-timeout", command, args...)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, design.StatusError, result.Status)
+	assert.NotEqual(t, 0, result.ExitCode)
+	assert.Less(t, elapsed, 750*time.Millisecond)
+
+	output := buf.String()
+	assert.Contains(t, output, designCfg.GetIcon("Error"))
+}

--- a/fo/tui_rendering_e2e_test.go
+++ b/fo/tui_rendering_e2e_test.go
@@ -1,0 +1,61 @@
+package fo
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dkoosis/fo/pkg/design"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsoleRunSections_RendersStatusIcons(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	t.Setenv(helperEnvKey, "1")
+
+	var buf bytes.Buffer
+	designCfg := design.UnicodeVibrantTheme()
+
+	console := NewConsole(ConsoleConfig{
+		Design:           designCfg,
+		ShowOutputMode:   "on-fail",
+		LiveStreamOutput: false,
+		Monochrome:       true,
+		Out:              &buf,
+		Err:              &buf,
+	})
+
+	successCmd, successArgs := helperCommand(t, "success", "--msg=section success")
+	failCmd, failArgs := helperCommand(t, "failure")
+
+	sections := []Section{
+		{
+			Name: "tui-success",
+			Run: func() error {
+				_, err := console.RunWithContext(ctx, "tui-success", successCmd, successArgs...)
+				return err
+			},
+			Summary: "completed rendering happy path",
+		},
+		{
+			Name: "tui-failure",
+			Run: func() error {
+				_, err := console.RunWithContext(ctx, "tui-failure", failCmd, failArgs...)
+				return err
+			},
+		},
+	}
+
+	results, err := console.RunSections(sections...)
+	require.Error(t, err)
+	require.Len(t, results, 2)
+
+	output := buf.String()
+	assert.Contains(t, output, designCfg.GetIcon("Success"))
+	assert.Contains(t, output, designCfg.GetIcon("Error"))
+	assert.Contains(t, output, "completed rendering happy path")
+}

--- a/pkg/sarif/sarif_e2e_test.go
+++ b/pkg/sarif/sarif_e2e_test.go
@@ -1,0 +1,179 @@
+package sarif
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dkoosis/fo/pkg/design"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const helperEnvKey = "FO_E2E_HELPER"
+
+func TestHelperProcess(t *testing.T) { //nolint:revive
+	t.Helper()
+
+	if os.Getenv(helperEnvKey) == "" {
+		return
+	}
+
+	args := filterHelperArgs(os.Args[1:])
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "no helper scenario provided")
+		os.Exit(2)
+	}
+
+	switch args[0] {
+	case "sarif-output":
+		path := extractValue(args[1:], "--sarif-path=", os.Getenv("FO_E2E_SARIF_PATH"))
+		if path == "" {
+			fmt.Fprintln(os.Stderr, "missing sarif path")
+			os.Exit(3)
+		}
+		if err := os.WriteFile(path, []byte(sampleSARIFDocument()), 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(4)
+		}
+		fmt.Println("sarif document written")
+		os.Exit(0)
+	case "sleep":
+		sleepMs := parseInt(args[1:], "--sleep-ms=", 100)
+		time.Sleep(time.Duration(sleepMs) * time.Millisecond)
+		fmt.Println("slept")
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown helper scenario: %s\n", args[0])
+	}
+
+	os.Exit(0)
+}
+
+func TestSarifOrchestrator_WritesDocumentsAndRendersSummaries(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	t.Setenv(helperEnvKey, "1")
+
+	tempDir := t.TempDir()
+	sarifPath := filepath.Join(tempDir, "e2e.sarif")
+
+	config := DefaultRendererConfig()
+	foConfig := design.UnicodeVibrantTheme()
+	orch := NewOrchestrator(config, foConfig)
+	orch.SetBuildDir(tempDir)
+
+	var buf bytes.Buffer
+	orch.SetWriter(&buf)
+
+	command, args := helperCommand(t, "sarif-output", "--sarif-path="+sarifPath)
+
+	results, err := orch.Run(ctx, []ToolSpec{
+		{
+			Name:      "demo-tool",
+			Command:   command,
+			Args:      args,
+			SARIFPath: sarifPath,
+		},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.NotNil(t, results[0].Document)
+
+	assert.FileExists(t, sarifPath)
+
+	data, readErr := os.ReadFile(sarifPath)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(data), `"ruleId": "E2E001"`)
+
+	stats := ComputeStats(results[0].Document)
+	assert.GreaterOrEqual(t, stats.TotalIssues, 1)
+
+	output := buf.String()
+	assert.Contains(t, output, "E2E001")
+}
+
+// --- Helper utilities duplicated locally to keep tests hermetic ---
+
+func helperCommand(t *testing.T, scenario string, extraArgs ...string) (string, []string) {
+	t.Helper()
+	args := []string{"-test.run=TestHelperProcess", "--", scenario}
+	args = append(args, extraArgs...)
+	return os.Args[0], args
+}
+
+func filterHelperArgs(args []string) []string {
+	for len(args) > 0 && strings.HasPrefix(args[0], "-test.") {
+		args = args[1:]
+	}
+	if len(args) > 0 && args[0] == "--" {
+		return args[1:]
+	}
+	return args
+}
+
+func extractValue(args []string, prefix, fallback string) string {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, prefix) {
+			return strings.TrimPrefix(arg, prefix)
+		}
+	}
+	return fallback
+}
+
+func parseInt(args []string, prefix string, fallback int) int {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, prefix) {
+			value := strings.TrimPrefix(arg, prefix)
+			if n, err := strconv.Atoi(value); err == nil {
+				return n
+			}
+		}
+	}
+	return fallback
+}
+
+func sampleSARIFDocument() string {
+	return `{
+  "version": "2.1.0",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.6.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "e2e-lint",
+          "rules": [
+            {
+              "id": "E2E001",
+              "shortDescription": { "text": "demo issue" }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "E2E001",
+          "level": "error",
+          "message": { "text": "found a demo issue" },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "sample.go" },
+                "region": { "startLine": 3, "startColumn": 1 }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}`
+}


### PR DESCRIPTION
Summary:
- Adds E2E subsystem tests for fo’s orchestration/output/TUI flows using real temp FS and helper-process mock CLIs.

Key points:
- No internal mocking; uses helper-process binaries and real design config/matchers.
- Captures console/TUI output and asserts key markers (success/fail icons).
- Asserts SARIF is written and Task state is populated.
- Adds timeouts to prevent hangs.

How to test:
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945cf2905108325a5c22590152902c4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds E2E tests using a helper process to validate console orchestration (timeouts/capture), go test JSON handling, TUI rendering, and SARIF output; also broadens success indicator assertion.
> 
> - **Tests**:
>   - Add E2E coverage for console/orchestrator in `fo/`:
>     - `fo/orchestrator_e2e_test.go`: validates timeouts, duration, captured output, and success/error icons.
>     - `fo/gotestjson_e2e_test.go`: processes go test JSON end-to-end, checks pass/fail counts and coverage, and task state.
>     - `fo/tui_rendering_e2e_test.go`: runs sections and asserts rendered success/error icons and summaries.
>   - Add SARIF orchestration E2E in `pkg/sarif/sarif_e2e_test.go`: runs tool, writes SARIF to disk, reads back, and renders summary/stats.
>   - Introduce helper subprocess utilities in `fo/e2e_test_helpers_test.go` (and locally in SARIF tests) to simulate scenarios (`success`, `slow-success`, `failure`, `go-test-json`, `sarif-output`).
> - **Minor**:
>   - Expand success indicator assertion in `cmd/fo/main_test.go` to also accept `[OK]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb9dd55a75c6792469ed47c098da5c4842961b87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->