### PR TITLE
Add tests for dashboard suite and tasks

### DIFF
--- a/pkg/dashboard/suite_test.go
+++ b/pkg/dashboard/suite_test.go
@@ -1,0 +1,89 @@
+package dashboard
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSuite_HandlesResults_When_RunningWithNonTTYOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		specs     []TaskSpec
+		wantErr   error
+		wantCode  int
+		wantLines []string
+	}{
+		{
+			name: "success: returns nil when all tasks succeed",
+			specs: []TaskSpec{
+				{Group: "Build", Name: "fmt", Command: "printf 'done\n'"},
+				{Group: "Lint", Name: "noop", Command: "printf 'ok\n'"},
+			},
+			wantCode:  0,
+			wantLines: []string{"[Build/fmt] done", "[Lint/noop] ok", "✓ Build/fmt", "✓ Lint/noop"},
+		},
+		{
+			name: "error: returns SuiteError when any task fails",
+			specs: []TaskSpec{
+				{Group: "Test", Name: "pass", Command: "printf 'pass\n'"},
+				{Group: "Test", Name: "fail", Command: "printf 'fail\n' && exit 3"},
+			},
+			wantErr:   &SuiteError{ExitCode: 1},
+			wantCode:  1,
+			wantLines: []string{"[Test/pass] pass", "[Test/fail] fail", "✓ Test/pass", "✗ Test/fail"},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+
+			var buf bytes.Buffer
+			suite := NewSuite("non-tty")
+			for _, spec := range tc.specs {
+				suite.AddTask(spec.Group, spec.Name, spec.Command)
+			}
+
+			err := suite.RunWithOutput(ctx, &buf)
+			output := buf.String()
+
+			if tc.wantErr != nil {
+				var suiteErr *SuiteError
+				require.ErrorAs(t, err, &suiteErr)
+				assert.Equal(t, tc.wantCode, suiteErr.ExitCode)
+			} else {
+				require.NoError(t, err)
+			}
+
+			for _, line := range tc.wantLines {
+				assert.Contains(t, output, line, "expected output to include %q", line)
+			}
+		})
+	}
+}
+
+func TestSuite_SkipsExecution_When_NoTasksProvided(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	var buf bytes.Buffer
+	suite := NewSuite("empty")
+
+	err := suite.RunWithOutput(ctx, &buf)
+
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+}

--- a/pkg/dashboard/task_test.go
+++ b/pkg/dashboard/task_test.go
@@ -1,0 +1,76 @@
+package dashboard
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTask_StartTasks_UpdatesStatusAndOutput_When_CommandsSucceedAndFail(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	specs := []TaskSpec{
+		{Group: "GroupA", Name: "success", Command: "printf 'stdout\n'"},
+		{Group: "GroupB", Name: "failure", Command: "printf 'stderr\n' 1>&2; exit 2"},
+	}
+
+	tasks, updates := StartTasks(ctx, specs)
+	for update := range updates {
+		task := tasks[update.Index]
+		if update.Line != "" {
+			task.appendLine(update.Line)
+		}
+		task.Status = update.Status
+		if update.ExitCode != 0 {
+			task.ExitCode = update.ExitCode
+		}
+	}
+
+	require.Len(t, tasks, 2)
+
+	assert.Equal(t, TaskSuccess, tasks[0].Status)
+	assert.Equal(t, 0, tasks[0].ExitCode)
+	assert.Contains(t, tasks[0].GetOutput(), "stdout")
+
+	assert.Equal(t, TaskFailed, tasks[1].Status)
+	assert.Equal(t, 2, tasks[1].ExitCode)
+	assert.Contains(t, tasks[1].GetOutput(), "stderr")
+}
+
+func TestTask_AppendsOutputWithinBounds_When_LinesExceedBuffer(t *testing.T) {
+	t.Parallel()
+
+	task := &Task{}
+	total := defaultBufferLines + 10
+	for i := 0; i < total; i++ {
+		task.appendLine(fmt.Sprintf("line-%d", i))
+	}
+
+	output := task.GetOutput()
+	assert.Equal(t, defaultBufferLines, len(output))
+	assert.Equal(t, fmt.Sprintf("line-%d", total-defaultBufferLines), output[0])
+	assert.Equal(t, fmt.Sprintf("line-%d", total-1), output[len(output)-1])
+
+	originalLast := output[len(output)-1]
+	output[0] = "mutated"
+	assert.Equal(t, originalLast, task.GetOutput()[len(output)-1], "returned slice should be a copy")
+}
+
+func TestTask_DurationReflectsState_When_UnfinishedAndFinished(t *testing.T) {
+	t.Parallel()
+
+	start := time.Now().Add(-500 * time.Millisecond)
+	task := &Task{StartedAt: start}
+
+	require.InDelta(t, 500*time.Millisecond, task.Duration(), float64(400*time.Millisecond))
+
+	task.FinishedAt = start.Add(750 * time.Millisecond)
+	assert.Equal(t, 750*time.Millisecond, task.Duration())
+}


### PR DESCRIPTION
## Summary
- add suite tests covering non-tty execution success, failure, and empty suites
- add task tests exercising concurrent execution, output buffering, and duration handling

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69487fd62a248325ae452ade541fe562)