### PR TITLE
fo: consolidate dashboard JSON parsing and simplify SARIF reader

### DIFF
--- a/CandidateReport.md
+++ b/CandidateReport.md
@@ -1,0 +1,127 @@
+# Candidate Report — Go consolidation/simplification
+
+## Baseline QA status
+- `mage qa`: not available in this environment (`mage` not found).
+- `go test ./...`: ✅ completed in ~1m17s.
+- `gocyclo` / `scc` / `cloc`: not installed.
+
+## Discovery map (high-level)
+- Dashboard formatters in `pkg/dashboard/*` contain repeated JSON extraction/parsing and fallback logic.
+- SARIF reader in `pkg/sarif/reader.go` duplicates decode/validation paths.
+- Multiple formatters do nearly identical “find JSON in mixed output” logic.
+- JSON report parsing appears across `pkg/dashboard/formatter_*.go` with similar control flow.
+
+## Ranked consolidation candidates (10+)
+Ranking heuristic: (leverage * safety * clarity) / (risk * churn)
+
+1. **Unify JSON parsing in dashboard formatters**
+   - Locations: `pkg/dashboard/formatter_kgbaseline.go`, `formatter_orcahygiene.go`, `formatter_nugstats.go`, `formatter_mcperrors.go`, `formatter_telemetrysignals.go`.
+   - Duplication: repeated `strings.Join` + `strings.Index("{")` + `json.Unmarshal` + fallback.
+   - Proposal: shared helper for “JSON with leading noise” decoding.
+   - Expected win: ~30–40 LOC removed; fewer parsing variants.
+   - Risk: Low.
+   - Tests: reuse existing formatter tests.
+   - Migration: replace inline blocks with helper.
+
+2. **Unify JSON parsing for clean dashboard outputs**
+   - Locations: `pkg/dashboard/formatter_archlint.go`, `formatter_filesize.go`, `formatter_sarif.go`.
+   - Duplication: `strings.Join` + `json.Unmarshal` + fallback.
+   - Proposal: shared helper for straight JSON decoding.
+   - Expected win: small LOC reduction; consistent behavior.
+   - Risk: Low.
+   - Tests: reuse existing tests.
+   - Migration: swap parsing blocks.
+
+3. **Consolidate SARIF reader validation**
+   - Location: `pkg/sarif/reader.go`.
+   - Duplication: `Read` and `ReadBytes` each decode + validate version.
+   - Proposal: single validation helper; have `ReadBytes` use `Read`.
+   - Expected win: smaller reader surface; consistent error path.
+   - Risk: Low.
+   - Tests: existing SARIF tests.
+   - Migration: extract `validateDocument`.
+
+4. **Standardize JSON probe in dashboard status methods**
+   - Locations: `formatter_kgbaseline.go`, `formatter_orcahygiene.go`, `formatter_nugstats.go`, `formatter_mcperrors.go`.
+   - Duplication: status methods re-implement JSON extraction.
+   - Proposal: reuse helper for status path.
+   - Expected win: less drift between format and status logic.
+   - Risk: Low.
+   - Tests: existing status indicator tests.
+
+5. **Normalize file read/parse helpers in SARIF package**
+   - Locations: `pkg/sarif/reader.go`, `pkg/sarif/renderer.go`, `pkg/sarif/orchestrator.go`.
+   - Duplication: multiple file read + parse pathways.
+   - Proposal: consolidate file reading to `ReadFile` where applicable.
+   - Expected win: smaller API surface.
+   - Risk: Low/Medium (call site behavior).
+   - Tests: `pkg/sarif` tests.
+
+6. **Shared go test JSON parsing**
+   - Locations: `fo/testjson.go`, `pkg/dashboard/formatter_gotest.go`.
+   - Duplication: line-level JSON decoding + action handling.
+   - Proposal: shared parser or minimal helper to parse NDJSON lines.
+   - Expected win: medium LOC reduction.
+   - Risk: Medium (different output expectations).
+   - Tests: go test JSON parsing tests.
+
+7. **Consolidate “plain fallback” render path**
+   - Locations: most `pkg/dashboard/formatter_*.go` files.
+   - Duplication: repeated `return (&PlainFormatter{}).Format(...)`.
+   - Proposal: helper `plainFallback(lines, width)`.
+   - Expected win: small LOC reduction.
+   - Risk: Low.
+   - Tests: existing.
+
+8. **Unify JSON extraction for “mixed output” formatters**
+   - Locations: `formatter_golangcilint.go`, `formatter_govulncheck.go`, others with line scanning.
+   - Duplication: parse JSON line-by-line with simple detection.
+   - Proposal: helper to scan for JSON line containing a key.
+   - Expected win: small, clarity gain.
+   - Risk: Medium (heuristics).
+   - Tests: existing.
+
+9. **Normalize file/path utilities**
+   - Locations: `pkg/dashboard/*` uses `shortPath`, `trimPath`, etc.
+   - Duplication: repeated path trimming logic.
+   - Proposal: shared helper in dashboard package.
+   - Expected win: minor LOC reduction.
+   - Risk: Low.
+
+10. **Unify config file load logic**
+    - Locations: `internal/config/config.go` read paths repeated.
+    - Duplication: repeated `os.ReadFile` + yaml unmarshal + error wrapping.
+    - Proposal: helper to load YAML with path + defaults.
+    - Expected win: medium LOC reduction.
+    - Risk: Medium (config behavior).
+
+11. **Consolidate SARIF rendering counts**
+    - Locations: `pkg/sarif/renderer.go`, `pkg/sarif/orchestrator.go`.
+    - Duplication: count issues, filter levels.
+    - Proposal: move to `ComputeStats` results.
+    - Expected win: small code reduction + single source of truth.
+    - Risk: Low/Medium.
+
+## Chosen items (implemented)
+1. **Dashboard JSON parsing helpers**
+   - Before: every formatter repeated `strings.Join`/`Index`/`json.Unmarshal` and fallback.
+   - After: centralized helpers in `pkg/dashboard/json_helpers.go` used by multiple formatters.
+   - Risk: Low (pure refactor, same parsing behavior).
+
+2. **Dashboard status parsing reuse**
+   - Before: status methods repeated JSON extraction logic.
+   - After: status methods use shared helper for consistent decode path.
+   - Risk: Low.
+
+3. **SARIF reader validation consolidation**
+   - Before: `Read` and `ReadBytes` duplicated decode + validation.
+   - After: `ReadBytes` reuses `Read`, validation centralized.
+   - Risk: Low.
+
+## Deferred notes
+- Go test JSON consolidation across `fo/` and `pkg/dashboard/` deferred due to higher behavior risk (different output expectations).
+- Config loader consolidation deferred to avoid changing error wrapping and config resolution behavior.
+
+## Environment/tooling notes
+- `mage` is not installed, so QACommand could not be run here.
+- `gocyclo`, `scc`, and `cloc` are not available; consider adding them to the dev container/tooling.

--- a/pkg/dashboard/formatter_archlint.go
+++ b/pkg/dashboard/formatter_archlint.go
@@ -1,7 +1,6 @@
 package dashboard
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -41,9 +40,8 @@ func (f *GoArchLintFormatter) Format(lines []string, width int) string {
 	s := Styles()
 
 	// Parse JSON
-	fullOutput := strings.Join(lines, "\n")
 	var report archLintReport
-	if err := json.Unmarshal([]byte(fullOutput), &report); err != nil {
+	if !decodeJSONLines(lines, &report) {
 		return (&PlainFormatter{}).Format(lines, width)
 	}
 

--- a/pkg/dashboard/formatter_filesize.go
+++ b/pkg/dashboard/formatter_filesize.go
@@ -1,7 +1,6 @@
 package dashboard
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -76,9 +75,8 @@ func (f *FilesizeDashboardFormatter) Format(lines []string, width int) string {
 	var b strings.Builder
 
 	// Parse dashboard JSON
-	fullOutput := strings.Join(lines, "\n")
 	var dashboard FilesizeDashboard
-	if err := json.Unmarshal([]byte(fullOutput), &dashboard); err != nil {
+	if !decodeJSONLines(lines, &dashboard) {
 		return (&PlainFormatter{}).Format(lines, width)
 	}
 

--- a/pkg/dashboard/formatter_kgbaseline.go
+++ b/pkg/dashboard/formatter_kgbaseline.go
@@ -1,7 +1,6 @@
 package dashboard
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -55,17 +54,9 @@ type KGBaselineSummary struct {
 func (f *KGBaselineFormatter) Format(lines []string, width int) string {
 	var b strings.Builder
 
-	// Find JSON in output
-	fullOutput := strings.Join(lines, "\n")
-	jsonStart := strings.Index(fullOutput, "{")
-	if jsonStart == -1 {
-		return (&PlainFormatter{}).Format(lines, width)
-	}
-	jsonOutput := fullOutput[jsonStart:]
-
 	// Try to parse as KG baseline report
 	var report KGBaselineReport
-	if err := json.Unmarshal([]byte(jsonOutput), &report); err != nil {
+	if !decodeJSONLinesWithPrefix(lines, &report) {
 		return (&PlainFormatter{}).Format(lines, width)
 	}
 
@@ -219,15 +210,8 @@ func (f *KGBaselineFormatter) Format(lines []string, width int) string {
 
 // GetStatus implements StatusIndicator for content-aware menu icons.
 func (f *KGBaselineFormatter) GetStatus(lines []string) IndicatorStatus {
-	fullOutput := strings.Join(lines, "\n")
-	jsonStart := strings.Index(fullOutput, "{")
-	if jsonStart == -1 {
-		return IndicatorDefault
-	}
-	jsonOutput := fullOutput[jsonStart:]
-
 	var report KGBaselineReport
-	if err := json.Unmarshal([]byte(jsonOutput), &report); err != nil {
+	if !decodeJSONLinesWithPrefix(lines, &report) {
 		return IndicatorDefault
 	}
 

--- a/pkg/dashboard/formatter_mcperrors.go
+++ b/pkg/dashboard/formatter_mcperrors.go
@@ -1,7 +1,6 @@
 package dashboard
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -43,16 +42,8 @@ const maxErrorAgeDays = 5
 func (f *MCPErrorsFormatter) Format(lines []string, width int) string {
 	var b strings.Builder
 
-	// Find the JSON object in the output (skip any build/download messages)
-	fullOutput := strings.Join(lines, "\n")
-	jsonStart := strings.Index(fullOutput, "{")
-	if jsonStart == -1 {
-		return (&PlainFormatter{}).Format(lines, width)
-	}
-	jsonOutput := fullOutput[jsonStart:]
-
 	var report MCPErrorsReport
-	if err := json.Unmarshal([]byte(jsonOutput), &report); err != nil {
+	if !decodeJSONLinesWithPrefix(lines, &report) {
 		return (&PlainFormatter{}).Format(lines, width)
 	}
 
@@ -152,15 +143,8 @@ func (f *MCPErrorsFormatter) Format(lines []string, width int) string {
 
 // GetStatus implements StatusIndicator for content-aware menu icons.
 func (f *MCPErrorsFormatter) GetStatus(lines []string) IndicatorStatus {
-	fullOutput := strings.Join(lines, "\n")
-	jsonStart := strings.Index(fullOutput, "{")
-	if jsonStart == -1 {
-		return IndicatorDefault
-	}
-	jsonOutput := fullOutput[jsonStart:]
-
 	var report MCPErrorsReport
-	if err := json.Unmarshal([]byte(jsonOutput), &report); err != nil {
+	if !decodeJSONLinesWithPrefix(lines, &report) {
 		return IndicatorDefault
 	}
 

--- a/pkg/dashboard/formatter_nugstats.go
+++ b/pkg/dashboard/formatter_nugstats.go
@@ -1,7 +1,6 @@
 package dashboard
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -42,16 +41,8 @@ type NugstatsWeekly struct {
 func (f *NugstatsFormatter) Format(lines []string, width int) string {
 	var b strings.Builder
 
-	// Find the JSON object in the output (skip any build/download messages)
-	fullOutput := strings.Join(lines, "\n")
-	jsonStart := strings.Index(fullOutput, "{")
-	if jsonStart == -1 {
-		return (&PlainFormatter{}).Format(lines, width)
-	}
-	jsonOutput := fullOutput[jsonStart:]
-
 	var report NugstatsReport
-	if err := json.Unmarshal([]byte(jsonOutput), &report); err != nil {
+	if !decodeJSONLinesWithPrefix(lines, &report) {
 		return (&PlainFormatter{}).Format(lines, width)
 	}
 
@@ -145,15 +136,8 @@ func (f *NugstatsFormatter) Format(lines []string, width int) string {
 
 // GetStatus implements StatusIndicator for content-aware menu icons.
 func (f *NugstatsFormatter) GetStatus(lines []string) IndicatorStatus {
-	fullOutput := strings.Join(lines, "\n")
-	jsonStart := strings.Index(fullOutput, "{")
-	if jsonStart == -1 {
-		return IndicatorDefault
-	}
-	jsonOutput := fullOutput[jsonStart:]
-
 	var report NugstatsReport
-	if err := json.Unmarshal([]byte(jsonOutput), &report); err != nil {
+	if !decodeJSONLinesWithPrefix(lines, &report) {
 		return IndicatorDefault
 	}
 

--- a/pkg/dashboard/formatter_orcahygiene.go
+++ b/pkg/dashboard/formatter_orcahygiene.go
@@ -1,7 +1,6 @@
 package dashboard
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -35,16 +34,8 @@ type OrcaHygieneIssue struct {
 func (f *OrcaHygieneFormatter) Format(lines []string, width int) string {
 	var b strings.Builder
 
-	// Find the JSON object in the output (skip any build/download messages)
-	fullOutput := strings.Join(lines, "\n")
-	jsonStart := strings.Index(fullOutput, "{")
-	if jsonStart == -1 {
-		return (&PlainFormatter{}).Format(lines, width)
-	}
-	jsonOutput := fullOutput[jsonStart:]
-
 	var report OrcaHygieneReport
-	if err := json.Unmarshal([]byte(jsonOutput), &report); err != nil {
+	if !decodeJSONLinesWithPrefix(lines, &report) {
 		return (&PlainFormatter{}).Format(lines, width)
 	}
 
@@ -126,15 +117,8 @@ func renderHygieneIssue(b *strings.Builder, issue OrcaHygieneIssue, pathStyle, m
 
 // GetStatus implements StatusIndicator for content-aware menu icons.
 func (f *OrcaHygieneFormatter) GetStatus(lines []string) IndicatorStatus {
-	fullOutput := strings.Join(lines, "\n")
-	jsonStart := strings.Index(fullOutput, "{")
-	if jsonStart == -1 {
-		return IndicatorDefault
-	}
-	jsonOutput := fullOutput[jsonStart:]
-
 	var report OrcaHygieneReport
-	if err := json.Unmarshal([]byte(jsonOutput), &report); err != nil {
+	if !decodeJSONLinesWithPrefix(lines, &report) {
 		return IndicatorDefault
 	}
 

--- a/pkg/dashboard/formatter_sarif.go
+++ b/pkg/dashboard/formatter_sarif.go
@@ -1,7 +1,6 @@
 package dashboard
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -51,9 +50,8 @@ func (f *SARIFFormatter) Format(lines []string, width int) string {
 	ruleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#626262"))
 
 	// Try to parse SARIF
-	fullOutput := strings.Join(lines, "\n")
 	var report SARIFReport
-	if err := json.Unmarshal([]byte(fullOutput), &report); err != nil {
+	if !decodeJSONLines(lines, &report) {
 		// Not SARIF, fall back to plain
 		return (&PlainFormatter{}).Format(lines, width)
 	}

--- a/pkg/dashboard/formatter_telemetrysignals.go
+++ b/pkg/dashboard/formatter_telemetrysignals.go
@@ -1,7 +1,6 @@
 package dashboard
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -72,16 +71,8 @@ type TelemetryZeroResults struct {
 func (f *TelemetrySignalsFormatter) Format(lines []string, width int) string {
 	var b strings.Builder
 
-	// Find the JSON object in the output (skip any build/download messages)
-	fullOutput := strings.Join(lines, "\n")
-	jsonStart := strings.Index(fullOutput, "{")
-	if jsonStart == -1 {
-		return (&PlainFormatter{}).Format(lines, width)
-	}
-	jsonOutput := fullOutput[jsonStart:]
-
 	var report TelemetrySignalsReport
-	if err := json.Unmarshal([]byte(jsonOutput), &report); err != nil {
+	if !decodeJSONLinesWithPrefix(lines, &report) {
 		return (&PlainFormatter{}).Format(lines, width)
 	}
 

--- a/pkg/dashboard/json_helpers.go
+++ b/pkg/dashboard/json_helpers.go
@@ -1,0 +1,27 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+func decodeJSONLines(lines []string, out any) bool {
+	fullOutput := strings.Join(lines, "\n")
+	return decodeJSONPayload(fullOutput, out)
+}
+
+func decodeJSONLinesWithPrefix(lines []string, out any) bool {
+	fullOutput := strings.Join(lines, "\n")
+	jsonStart := strings.Index(fullOutput, "{")
+	if jsonStart == -1 {
+		return false
+	}
+	return decodeJSONPayload(fullOutput[jsonStart:], out)
+}
+
+func decodeJSONPayload(payload string, out any) bool {
+	if err := json.Unmarshal([]byte(payload), out); err != nil {
+		return false
+	}
+	return true
+}

--- a/pkg/sarif/reader.go
+++ b/pkg/sarif/reader.go
@@ -1,6 +1,7 @@
 package sarif
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -24,27 +25,19 @@ func Read(r io.Reader) (*Document, error) {
 	if err := json.NewDecoder(r).Decode(&doc); err != nil {
 		return nil, fmt.Errorf("decode sarif: %w", err)
 	}
-
-	// Basic validation
-	if doc.Version == "" {
-		return nil, fmt.Errorf("missing sarif version")
-	}
-
-	return &doc, nil
+	return validateDocument(&doc)
 }
 
 // ReadBytes parses SARIF from a byte slice.
 func ReadBytes(data []byte) (*Document, error) {
-	var doc Document
-	if err := json.Unmarshal(data, &doc); err != nil {
-		return nil, fmt.Errorf("decode sarif: %w", err)
-	}
+	return Read(bytes.NewReader(data))
+}
 
+func validateDocument(doc *Document) (*Document, error) {
 	if doc.Version == "" {
 		return nil, fmt.Errorf("missing sarif version")
 	}
-
-	return &doc, nil
+	return doc, nil
 }
 
 // IsSARIF checks if data looks like a SARIF document.


### PR DESCRIPTION
### Motivation
- Reduce repeated JSON extraction/parsing and fallback logic across `pkg/dashboard` formatters to remove duplication and drift.
- Centralize SARIF decode/validation to make `pkg/sarif/reader.go` behavior consistent and smaller.
- Improve maintainability and reduce code size while preserving existing behavior and fallbacks.

### Description
- Add `pkg/dashboard/json_helpers.go` providing `decodeJSONLines` and `decodeJSONLinesWithPrefix` and wire those helpers into multiple formatters to replace inline `strings.Join`/`Index`/`json.Unmarshal` patterns.
- Update formatters and their `GetStatus` methods (`formatter_kgbaseline.go`, `formatter_orcahygiene.go`, `formatter_nugstats.go`, `formatter_mcperrors.go`, `formatter_telemetrysignals.go`, `formatter_archlint.go`, `formatter_filesize.go`, `formatter_sarif.go`) to use the shared decode helpers.
- Refactor `pkg/sarif/reader.go` to add `validateDocument` and make `ReadBytes` call `Read`, centralizing version validation.
- Add `CandidateReport.md` documenting the discovery, ranked candidates, implemented items, and environment/tooling notes.

### Testing
- Ran `go test ./...` and the test suite completed successfully.
- `mage qa` was not executed because `mage` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696653fa1f548325a7c7570e84ac1b1b)