### PR TITLE
Simplify testjson tests and add fuzz coverage

### DIFF
--- a/pkg/testjson/parser_test.go
+++ b/pkg/testjson/parser_test.go
@@ -5,125 +5,170 @@ import (
 	"testing"
 )
 
-func TestParseStream_BasicPassFail(t *testing.T) {
-	input := strings.Join([]string{
-		`{"Time":"2024-01-01T00:00:00Z","Action":"run","Package":"example.com/pkg","Test":"TestA"}`,
-		`{"Time":"2024-01-01T00:00:00Z","Action":"pass","Package":"example.com/pkg","Test":"TestA","Elapsed":0.1}`,
-		`{"Time":"2024-01-01T00:00:00Z","Action":"run","Package":"example.com/pkg","Test":"TestB"}`,
-		`{"Time":"2024-01-01T00:00:00Z","Action":"fail","Package":"example.com/pkg","Test":"TestB","Elapsed":0.2}`,
-		`{"Time":"2024-01-01T00:00:00Z","Action":"pass","Package":"example.com/pkg","Elapsed":0.5}`,
-	}, "\n") + "\n"
+func TestParseStream_Behavior(t *testing.T) {
+	t.Parallel()
 
-	results, malformed, err := ParseStream(strings.NewReader(input))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if malformed != 0 {
-		t.Errorf("expected 0 malformed, got %d", malformed)
-	}
-	if len(results) != 1 {
-		t.Fatalf("expected 1 package, got %d", len(results))
+	tests := []struct {
+		name            string
+		inputLines      []string
+		wantMalformed   int
+		wantPackageName string
+		wantPassed      int
+		wantFailed      int
+		wantSkipped     int
+		wantStatus      string
+		wantCoverage    float64
+		wantPanicked    bool
+		wantPackages    int
+	}{
+		{
+			name: "pass/fail aggregation and package status",
+			inputLines: []string{
+				`{"Time":"2024-01-01T00:00:00Z","Action":"run","Package":"example.com/pkg","Test":"TestA"}`,
+				`{"Time":"2024-01-01T00:00:00Z","Action":"pass","Package":"example.com/pkg","Test":"TestA","Elapsed":0.1}`,
+				`{"Time":"2024-01-01T00:00:00Z","Action":"run","Package":"example.com/pkg","Test":"TestB"}`,
+				`{"Time":"2024-01-01T00:00:00Z","Action":"fail","Package":"example.com/pkg","Test":"TestB","Elapsed":0.2}`,
+				`{"Time":"2024-01-01T00:00:00Z","Action":"pass","Package":"example.com/pkg","Elapsed":0.5}`,
+			},
+			wantMalformed:   0,
+			wantPackages:    1,
+			wantPackageName: "example.com/pkg",
+			wantPassed:      1,
+			wantFailed:      1,
+			wantStatus:      "fail",
+		},
+		{
+			name: "coverage is parsed from output",
+			inputLines: []string{
+				`{"Action":"run","Package":"example.com/pkg","Test":"TestA"}`,
+				`{"Action":"pass","Package":"example.com/pkg","Test":"TestA","Elapsed":0.1}`,
+				`{"Action":"output","Package":"example.com/pkg","Output":"coverage: 85.3% of statements\n"}`,
+				`{"Action":"pass","Package":"example.com/pkg","Elapsed":0.5}`,
+			},
+			wantMalformed:   0,
+			wantPackages:    1,
+			wantPackageName: "example.com/pkg",
+			wantPassed:      1,
+			wantCoverage:    85.3,
+			wantStatus:      "pass",
+		},
+		{
+			name: "panic output marks package as panicked",
+			inputLines: []string{
+				`{"Action":"run","Package":"example.com/pkg","Test":"TestBad"}`,
+				`{"Action":"output","Package":"example.com/pkg","Test":"TestBad","Output":"panic: runtime error: index out of range\n"}`,
+				`{"Action":"fail","Package":"example.com/pkg","Test":"TestBad","Elapsed":0.0}`,
+				`{"Action":"fail","Package":"example.com/pkg","Elapsed":0.0}`,
+			},
+			wantMalformed:   0,
+			wantPackages:    1,
+			wantPackageName: "example.com/pkg",
+			wantFailed:      1,
+			wantPanicked:    true,
+			wantStatus:      "fail",
+		},
+		{
+			name: "malformed lines are skipped and counted",
+			inputLines: []string{
+				`not json`,
+				`{bad json`,
+				`{"Action":"run","Package":"x","Test":"T"}`,
+				`{"Action":"pass","Package":"x","Test":"T","Elapsed":0.1}`,
+				`{"Action":"pass","Package":"x","Elapsed":0.1}`,
+			},
+			wantMalformed:   2,
+			wantPackages:    1,
+			wantPackageName: "x",
+			wantPassed:      1,
+			wantStatus:      "pass",
+		},
+		{
+			name: "package with no test activity is skipped",
+			inputLines: []string{
+				`{"Action":"start","Package":"example.com/empty"}`,
+			},
+			wantMalformed: 0,
+			wantPackages:  0,
+		},
 	}
 
-	r := results[0]
-	if r.Passed != 1 {
-		t.Errorf("expected 1 passed, got %d", r.Passed)
-	}
-	if r.Failed != 1 {
-		t.Errorf("expected 1 failed, got %d", r.Failed)
-	}
-	if r.Status() != "fail" { //nolint:goconst // test data
-		t.Errorf("expected status fail, got %s", r.Status())
-	}
-}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			input := strings.Join(tt.inputLines, "\n") + "\n"
+			results, malformed, err := ParseStream(strings.NewReader(input))
+			if err != nil {
+				t.Fatalf("ParseStream() error = %v", err)
+			}
+			if malformed != tt.wantMalformed {
+				t.Fatalf("malformed = %d, want %d", malformed, tt.wantMalformed)
+			}
+			if len(results) != tt.wantPackages {
+				t.Fatalf("packages = %d, want %d", len(results), tt.wantPackages)
+			}
+			if tt.wantPackages == 0 {
+				return
+			}
 
-func TestParseStream_Coverage(t *testing.T) {
-	input := strings.Join([]string{
-		`{"Time":"2024-01-01T00:00:00Z","Action":"run","Package":"example.com/pkg","Test":"TestA"}`,
-		`{"Time":"2024-01-01T00:00:00Z","Action":"pass","Package":"example.com/pkg","Test":"TestA","Elapsed":0.1}`,
-		`{"Time":"2024-01-01T00:00:00Z","Action":"output","Package":"example.com/pkg","Output":"coverage: 85.3% of statements\n"}`,
-		`{"Time":"2024-01-01T00:00:00Z","Action":"pass","Package":"example.com/pkg","Elapsed":0.5}`,
-	}, "\n") + "\n"
-
-	results, _, err := ParseStream(strings.NewReader(input))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(results) != 1 {
-		t.Fatalf("expected 1 package, got %d", len(results))
-	}
-	if results[0].Coverage < 85.0 || results[0].Coverage > 86.0 {
-		t.Errorf("expected coverage ~85.3, got %f", results[0].Coverage)
-	}
-}
-
-func TestParseStream_PanicDetection(t *testing.T) {
-	input := strings.Join([]string{
-		`{"Time":"2024-01-01T00:00:00Z","Action":"run","Package":"example.com/pkg","Test":"TestBad"}`,
-		`{"Time":"2024-01-01T00:00:00Z","Action":"output","Package":"example.com/pkg","Test":"TestBad","Output":"panic: runtime error: index out of range\n"}`,
-		`{"Time":"2024-01-01T00:00:00Z","Action":"fail","Package":"example.com/pkg","Test":"TestBad","Elapsed":0.0}`,
-		`{"Time":"2024-01-01T00:00:00Z","Action":"fail","Package":"example.com/pkg","Elapsed":0.0}`,
-	}, "\n") + "\n"
-
-	results, _, err := ParseStream(strings.NewReader(input))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(results) != 1 {
-		t.Fatalf("expected 1 package, got %d", len(results))
-	}
-	if !results[0].Panicked {
-		t.Error("expected panic detected")
-	}
-}
-
-func TestParseStream_SkipsEmptyPackages(t *testing.T) {
-	// A package with only "start" action and no tests should be skipped
-	input := `{"Time":"2024-01-01T00:00:00Z","Action":"start","Package":"example.com/empty"}` + "\n"
-
-	results, _, err := ParseStream(strings.NewReader(input))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(results) != 0 {
-		t.Errorf("expected 0 packages, got %d", len(results))
-	}
-}
-
-func TestParseStream_MalformedLinesSkipped(t *testing.T) {
-	input := "not json\n{bad json\n" +
-		`{"Time":"2024-01-01T00:00:00Z","Action":"run","Package":"x","Test":"T"}` + "\n" +
-		`{"Time":"2024-01-01T00:00:00Z","Action":"pass","Package":"x","Test":"T","Elapsed":0.1}` + "\n" +
-		`{"Time":"2024-01-01T00:00:00Z","Action":"pass","Package":"x","Elapsed":0.1}` + "\n"
-
-	results, malformed, err := ParseStream(strings.NewReader(input))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if malformed != 2 {
-		t.Errorf("expected 2 malformed lines, got %d", malformed)
-	}
-	if len(results) != 1 {
-		t.Fatalf("expected 1 package (skipping malformed), got %d", len(results))
-	}
-	if results[0].Passed != 1 {
-		t.Errorf("expected 1 passed, got %d", results[0].Passed)
+			got := results[0]
+			if got.Name != tt.wantPackageName {
+				t.Fatalf("package name = %q, want %q", got.Name, tt.wantPackageName)
+			}
+			if got.Passed != tt.wantPassed {
+				t.Fatalf("passed = %d, want %d", got.Passed, tt.wantPassed)
+			}
+			if got.Failed != tt.wantFailed {
+				t.Fatalf("failed = %d, want %d", got.Failed, tt.wantFailed)
+			}
+			if got.Skipped != tt.wantSkipped {
+				t.Fatalf("skipped = %d, want %d", got.Skipped, tt.wantSkipped)
+			}
+			if tt.wantStatus != "" && got.Status() != tt.wantStatus {
+				t.Fatalf("status = %q, want %q", got.Status(), tt.wantStatus)
+			}
+			if tt.wantCoverage > 0 && (got.Coverage < tt.wantCoverage-0.01 || got.Coverage > tt.wantCoverage+0.01) {
+				t.Fatalf("coverage = %.2f, want %.2f", got.Coverage, tt.wantCoverage)
+			}
+			if got.Panicked != tt.wantPanicked {
+				t.Fatalf("panicked = %t, want %t", got.Panicked, tt.wantPanicked)
+			}
+		})
 	}
 }
 
 func TestComputeStats(t *testing.T) {
+	t.Parallel()
+
 	results := []TestPackageResult{
 		{Name: "a", Passed: 5, Failed: 1, Skipped: 0},
 		{Name: "b", Passed: 3, Failed: 0, Skipped: 2},
 	}
 	s := ComputeStats(results)
+
 	if s.TotalTests != 11 {
-		t.Errorf("expected 11 total tests, got %d", s.TotalTests)
+		t.Fatalf("total tests = %d, want 11", s.TotalTests)
 	}
 	if s.Failed != 1 {
-		t.Errorf("expected 1 failed, got %d", s.Failed)
+		t.Fatalf("failed tests = %d, want 1", s.Failed)
 	}
 	if s.FailedPkgs != 1 {
-		t.Errorf("expected 1 failed pkg, got %d", s.FailedPkgs)
+		t.Fatalf("failed packages = %d, want 1", s.FailedPkgs)
 	}
+}
+
+func FuzzParseStream(f *testing.F) {
+	f.Add(`{"Action":"run","Package":"x","Test":"T"}` + "\n" + `{"Action":"pass","Package":"x","Test":"T","Elapsed":0.1}` + "\n")
+	f.Add(`not-json` + "\n" + `{"Action":"output","Package":"x","Output":"coverage: 80.0% of statements\n"}` + "\n")
+	f.Add(`{"Action":"output","Package":"x","Output":"panic: boom\n"}` + "\n" + `{"Action":"fail","Package":"x","Elapsed":0.0}` + "\n")
+
+	f.Fuzz(func(t *testing.T, input string) {
+		results, malformed, err := ParseStream(strings.NewReader(input))
+		if err != nil {
+			t.Fatalf("ParseStream should not fail for arbitrary input: %v", err)
+		}
+		if malformed < 0 {
+			t.Fatalf("malformed should never be negative: %d", malformed)
+		}
+		_ = ComputeStats(results)
+	})
 }

--- a/pkg/testjson/stream_test.go
+++ b/pkg/testjson/stream_test.go
@@ -9,62 +9,89 @@ import (
 	"time"
 )
 
-func TestStream_CallsFuncForEachEvent(t *testing.T) {
-	input := strings.Join([]string{
-		`{"Action":"start","Package":"example.com/pkg"}`,
-		`{"Action":"run","Package":"example.com/pkg","Test":"TestFoo"}`,
-		`{"Action":"pass","Package":"example.com/pkg","Test":"TestFoo","Elapsed":0.01}`,
-		`{"Action":"pass","Package":"example.com/pkg","Elapsed":0.5}`,
-	}, "\n") + "\n"
+func TestStream_EventDeliveryAndMalformedCounting(t *testing.T) {
+	t.Parallel()
 
-	var events []TestEvent
-	malformed, err := Stream(context.Background(), strings.NewReader(input), func(e TestEvent) {
-		events = append(events, e)
-	})
-	if err != nil {
-		t.Fatalf("Stream() error: %v", err)
-	}
-	if malformed != 0 {
-		t.Errorf("got %d malformed, want 0", malformed)
-	}
-	if len(events) != 4 {
-		t.Fatalf("got %d events, want 4", len(events))
-	}
-	if events[0].Action != "start" {
-		t.Errorf("events[0].Action = %q, want \"start\"", events[0].Action)
-	}
-	if events[2].Test != "TestFoo" {
-		t.Errorf("events[2].Test = %q, want \"TestFoo\"", events[2].Test)
-	}
-}
-
-func TestStream_SkipsMalformedLines(t *testing.T) {
-	input := `not json
+	tests := []struct {
+		name          string
+		input         string
+		wantMalformed int
+		wantEvents    int
+		check         func(t *testing.T, events []TestEvent)
+	}{
+		{
+			name: "valid stream emits all events in order",
+			input: strings.Join([]string{
+				`{"Action":"start","Package":"example.com/pkg"}`,
+				`{"Action":"run","Package":"example.com/pkg","Test":"TestFoo"}`,
+				`{"Action":"pass","Package":"example.com/pkg","Test":"TestFoo","Elapsed":0.01}`,
+				`{"Action":"pass","Package":"example.com/pkg","Elapsed":0.5}`,
+			}, "\n") + "\n",
+			wantMalformed: 0,
+			wantEvents:    4,
+			check: func(t *testing.T, events []TestEvent) {
+				t.Helper()
+				if events[0].Action != "start" {
+					t.Fatalf("events[0].Action = %q, want start", events[0].Action)
+				}
+				if events[2].Test != "TestFoo" {
+					t.Fatalf("events[2].Test = %q, want TestFoo", events[2].Test)
+				}
+			},
+		},
+		{
+			name: "malformed lines are skipped",
+			input: `not json
 {"Action":"start","Package":"example.com/pkg"}
 also not json
 {"Action":"pass","Package":"example.com/pkg","Elapsed":0.1}
-`
-	var events []TestEvent
-	malformed, err := Stream(context.Background(), strings.NewReader(input), func(e TestEvent) {
-		events = append(events, e)
-	})
-	if err != nil {
-		t.Fatalf("Stream() error: %v", err)
+`,
+			wantMalformed: 2,
+			wantEvents:    2,
+		},
+		{
+			name: "mixed malformed and valid lines",
+			input: strings.Join([]string{
+				`{"Action":"run","Package":"x","Test":"T1"}`,
+				`{CORRUPTED}`,
+				`{"Action":"fail","Package":"x","Test":"T1","Elapsed":0.1}`,
+				`not-json-at-all`,
+				`{"Action":"fail","Package":"x","Elapsed":0.2}`,
+			}, "\n") + "\n",
+			wantMalformed: 2,
+			wantEvents:    3,
+		},
 	}
-	if malformed != 2 {
-		t.Errorf("got %d malformed, want 2", malformed)
-	}
-	if len(events) != 2 {
-		t.Fatalf("got %d events, want 2 (malformed lines skipped)", len(events))
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			var events []TestEvent
+			malformed, err := Stream(context.Background(), strings.NewReader(tt.input), func(e TestEvent) {
+				events = append(events, e)
+			})
+			if err != nil {
+				t.Fatalf("Stream() error: %v", err)
+			}
+			if malformed != tt.wantMalformed {
+				t.Fatalf("malformed = %d, want %d", malformed, tt.wantMalformed)
+			}
+			if len(events) != tt.wantEvents {
+				t.Fatalf("events = %d, want %d", len(events), tt.wantEvents)
+			}
+			if tt.check != nil {
+				tt.check(t, events)
+			}
+		})
 	}
 }
 
 func TestStream_RespectsContextCancellation(t *testing.T) {
-	input := `{"Action":"start","Package":"example.com/pkg"}` + "\n"
+	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var count int
-	_, err := Stream(ctx, strings.NewReader(input), func(_ TestEvent) {
+	_, err := Stream(ctx, strings.NewReader(`{"Action":"start","Package":"example.com/pkg"}`+"\n"), func(_ TestEvent) {
 		count++
 		cancel()
 	})
@@ -72,7 +99,7 @@ func TestStream_RespectsContextCancellation(t *testing.T) {
 		t.Fatalf("Stream() unexpected error: %v", err)
 	}
 	if count != 1 {
-		t.Errorf("got %d events, want 1", count)
+		t.Fatalf("events processed = %d, want 1", count)
 	}
 }
 
@@ -96,6 +123,8 @@ func (b *blockingReader) Close() error {
 }
 
 func TestStream_CancelUnblocksBlockedReader(t *testing.T) {
+	t.Parallel()
+
 	br := &blockingReader{done: make(chan struct{})}
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
@@ -112,31 +141,6 @@ func TestStream_CancelUnblocksBlockedReader(t *testing.T) {
 			t.Fatalf("expected DeadlineExceeded, got: %v", err)
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("Stream did not return after context cancellation — blocked on reader")
-	}
-}
-
-func TestStream_MalformedCountReturned(t *testing.T) {
-	// Mix of valid and invalid NDJSON with a corrupted fail event.
-	input := strings.Join([]string{
-		`{"Action":"run","Package":"x","Test":"T1"}`,
-		`{CORRUPTED}`,
-		`{"Action":"fail","Package":"x","Test":"T1","Elapsed":0.1}`,
-		`not-json-at-all`,
-		`{"Action":"fail","Package":"x","Elapsed":0.2}`,
-	}, "\n") + "\n"
-
-	var events []TestEvent
-	malformed, err := Stream(context.Background(), strings.NewReader(input), func(e TestEvent) {
-		events = append(events, e)
-	})
-	if err != nil {
-		t.Fatalf("Stream() error: %v", err)
-	}
-	if malformed != 2 {
-		t.Errorf("got %d malformed, want 2", malformed)
-	}
-	if len(events) != 3 {
-		t.Errorf("got %d events, want 3", len(events))
+		t.Fatal("Stream did not return after context cancellation")
 	}
 }


### PR DESCRIPTION
### Motivation
- Reduce duplicated, implementation-focused tests in `pkg/testjson` and make the suite easier to maintain.
- Shift tests to exercise observable behavior of the parser and stream consumer for `go test -json` NDJSON input.
- Increase robustness against malformed inputs by adding fuzz coverage for the parser.

### Description
- Rewrote `pkg/testjson/parser_test.go` into a table-driven `TestParseStream_Behavior` and added a seeded `FuzzParseStream` to exercise `ParseStream` with arbitrary inputs. 
- Consolidated `pkg/testjson/stream_test.go` into a table-driven `TestStream_EventDeliveryAndMalformedCounting` and kept focused tests for context cancellation and unblocking behavior of `Stream`.
- Simplified assertions to check final, externally observable outcomes, added `t.Parallel()` where appropriate, and applied formatting cleanup (`gofumpt`/`goimports`).

### Testing
- Ran `go test ./pkg/testjson` and the package tests passed.
- Ran `go test ./...` and all repository tests passed.
- Applied formatting with `gofumpt -w` and `goimports -w` to the modified test files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b363863620832599a10d2f2dc6c74e)