### PR TITLE
Simplify pkg/render tests to focus on observable behavior

### DIFF
--- a/pkg/render/llm_test.go
+++ b/pkg/render/llm_test.go
@@ -1,61 +1,76 @@
-package render
+package render_test
 
 import (
 	"strings"
 	"testing"
 
 	"github.com/dkoosis/fo/pkg/pattern"
+	"github.com/dkoosis/fo/pkg/render"
 )
 
-func TestLLM_RenderReport(t *testing.T) {
-	patterns := []pattern.Pattern{
-		&pattern.Summary{
-			Label: "REPORT: 2 tools — all pass",
-			Kind:  pattern.SummaryKindReport,
-			Metrics: []pattern.SummaryItem{
-				{Label: "vet", Value: "0 diags", Kind: "success"},
-				{Label: "arch", Value: "pass", Kind: "success"},
+func TestLLMRender_KeyUserVisibleOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		patterns []pattern.Pattern
+		wants    []string
+	}{
+		{
+			name: "report includes per-tool summary and failed checks",
+			patterns: []pattern.Pattern{
+				&pattern.Summary{
+					Label: "REPORT: 3 tools — 1 fail, 2 pass",
+					Kind:  pattern.SummaryKindReport,
+					Metrics: []pattern.SummaryItem{
+						{Label: "vet", Value: "0 diags", Kind: pattern.KindSuccess},
+						{Label: "lint", Value: "2 err", Kind: pattern.KindError},
+					},
+				},
+				&pattern.TestTable{
+					Label:  "lint violations",
+					Source: "lint",
+					Results: []pattern.TestTableItem{
+						{Name: "store → eval", Status: "fail", Details: "forbidden dependency"},
+					},
+				},
 			},
+			wants: []string{"REPORT: 3 tools — 1 fail, 2 pass", "vet: 0 diags", "## lint violations", "FAIL store → eval", "forbidden dependency"},
+		},
+		{
+			name: "test summary mode includes scope and status lines",
+			patterns: []pattern.Pattern{
+				&pattern.Summary{Label: "pkg/foo", Kind: pattern.SummaryKindTest},
+				&pattern.TestTable{
+					Label: "failed tests",
+					Results: []pattern.TestTableItem{
+						{Name: "TestParser", Status: "fail", Duration: "0.02s", Details: "panic: boom"},
+					},
+				},
+			},
+			wants: []string{"SCOPE: pkg/foo", "failed tests", "FAIL TestParser (0.02s)", "panic: boom"},
+		},
+		{
+			name: "sarif mode derives scope and groups by file",
+			patterns: []pattern.Pattern{
+				&pattern.TestTable{
+					Label: "pkg/a.go",
+					Results: []pattern.TestTableItem{
+						{Name: "RULE001:12:3", Status: "fail", Details: "bad thing"},
+					},
+				},
+			},
+			wants: []string{"SCOPE: 1 files, 1 diags", "## pkg/a.go", "ERR RULE001:12:3 bad thing"},
 		},
 	}
-	r := NewLLM()
-	out := r.Render(patterns)
-	if !strings.Contains(out, "REPORT:") {
-		t.Errorf("expected REPORT header in output:\n%s", out)
-	}
-	if !strings.Contains(out, "vet: 0 diags") {
-		t.Errorf("expected tool summary line in output:\n%s", out)
-	}
-}
 
-func TestLLM_RenderReportWithFailures(t *testing.T) {
-	patterns := []pattern.Pattern{
-		&pattern.Summary{
-			Label: "REPORT: 3 tools — 1 fail, 2 pass",
-			Kind:  pattern.SummaryKindReport,
-			Metrics: []pattern.SummaryItem{
-				{Label: "vet", Value: "0 diags", Kind: "success"},
-				{Label: "lint", Value: "2 err", Kind: "error"},
-				{Label: "arch", Value: "pass", Kind: "success"},
-			},
-		},
-		&pattern.TestTable{
-			Label:  "lint violations",
-			Source: "lint",
-			Results: []pattern.TestTableItem{
-				{Name: "store → eval", Status: "fail", Details: "forbidden dependency"},
-			},
-		},
-	}
-	r := NewLLM()
-	out := r.Render(patterns)
-	if !strings.Contains(out, "1 fail") {
-		t.Errorf("expected failure count in output:\n%s", out)
-	}
-	if !strings.Contains(out, "lint violations") {
-		t.Errorf("expected table label in output:\n%s", out)
-	}
-	if !strings.Contains(out, "FAIL store → eval") {
-		t.Errorf("expected violation detail in output:\n%s", out)
+	r := render.NewLLM()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out := r.Render(tc.patterns)
+			for _, want := range tc.wants {
+				if !strings.Contains(out, want) {
+					t.Fatalf("expected output to contain %q, got:\n%s", want, out)
+				}
+			}
+		})
 	}
 }

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -1,26 +1,35 @@
-package render
+package render_test
 
 import (
 	"strings"
 	"testing"
 
 	"github.com/dkoosis/fo/pkg/pattern"
+	"github.com/dkoosis/fo/pkg/render"
 )
 
-func TestTerminal_RenderReportPatterns(t *testing.T) {
-	patterns := []pattern.Pattern{
+type unknownPattern struct{}
+
+func (unknownPattern) Type() pattern.PatternType { return "unknown" }
+
+func TestTerminalRender_ShowsSummaryAndSkipsUnknownPatterns(t *testing.T) {
+	r := render.NewTerminal(render.MonoTheme(), 80)
+
+	out := r.Render([]pattern.Pattern{
 		&pattern.Summary{
 			Label: "REPORT: 2 tools — all pass",
 			Kind:  pattern.SummaryKindReport,
 			Metrics: []pattern.SummaryItem{
-				{Label: "vet", Value: "0 diags", Kind: "success"},
-				{Label: "test", Value: "PASS — 60 tests", Kind: "success"},
+				{Label: "vet", Value: "0 diags", Kind: pattern.KindSuccess},
+				{Label: "test", Value: "PASS — 60 tests", Kind: pattern.KindSuccess},
 			},
 		},
-	}
-	r := NewTerminal(MonoTheme(), 80)
-	out := r.Render(patterns)
-	if !strings.Contains(out, "REPORT:") {
-		t.Errorf("expected REPORT in output:\n%s", out)
+		unknownPattern{},
+	})
+
+	for _, want := range []string{"REPORT:", "vet: 0 diags", "test: PASS — 60 tests"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected output to contain %q, got:\n%s", want, out)
+		}
 	}
 }


### PR DESCRIPTION
### Motivation
- Replace brittle, implementation-focused tests in `pkg/render` with simpler black-box tests that assert user-visible output.
- Reduce scaffolding and test fragility by exercising real renderers and minimizing mocks so tests survive refactors.

### Description
- Converted tests to the external `render_test` package and simplified `pkg/render/render_test.go` to assert terminal output contains summary lines and tolerates unknown pattern types.
- Consolidated LLM tests into a single table-driven test in `pkg/render/llm_test.go` that verifies report, test-summary, and SARIF rendering flows via user-visible strings.
- Removed fragile implementation assertions and excessive scaffolding, and added a minimal `unknownPattern` helper to validate unknown-pattern skipping.

### Testing
- Ran `go test ./pkg/render` which passed.
- Ran `go test ./...` and the full test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b36b3be500832594cab9490eb1b0a7)