### PR TITLE
test: add external contract tests for pattern and wrapper registry

### DIFF
--- a/pkg/pattern/pattern_external_test.go
+++ b/pkg/pattern/pattern_external_test.go
@@ -1,0 +1,90 @@
+package pattern_test
+
+import (
+	"testing"
+
+	"github.com/dkoosis/fo/pkg/pattern"
+)
+
+func TestPatternTypes_AreStable_When_ConstructingKnownPatternValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		item pattern.Pattern
+		want pattern.PatternType
+	}{
+		{name: "summary", item: &pattern.Summary{}, want: pattern.PatternTypeSummary},
+		{name: "leaderboard", item: &pattern.Leaderboard{}, want: pattern.PatternTypeLeaderboard},
+		{name: "test table", item: &pattern.TestTable{}, want: pattern.PatternTypeTestTable},
+		{name: "sparkline", item: &pattern.Sparkline{}, want: pattern.PatternTypeSparkline},
+		{name: "comparison", item: &pattern.Comparison{}, want: pattern.PatternTypeComparison},
+		{name: "error", item: &pattern.Error{}, want: pattern.PatternTypeError},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.item.Type(); got != tt.want {
+				t.Fatalf("Type() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSummaryKinds_AreDistinct_When_UsedForRenderDispatch(t *testing.T) {
+	t.Parallel()
+
+	kinds := []pattern.SummaryKind{pattern.SummaryKindSARIF, pattern.SummaryKindTest, pattern.SummaryKindReport}
+	seen := make(map[pattern.SummaryKind]struct{}, len(kinds))
+	for _, kind := range kinds {
+		if _, ok := seen[kind]; ok {
+			t.Fatalf("duplicate SummaryKind detected: %q", kind)
+		}
+		seen[kind] = struct{}{}
+	}
+}
+
+func TestTestTableStatuses_AreDistinct_When_FilteringRowsByOutcome(t *testing.T) {
+	t.Parallel()
+
+	statuses := []pattern.Status{pattern.StatusPass, pattern.StatusFail, pattern.StatusSkip}
+	seen := make(map[pattern.Status]struct{}, len(statuses))
+	for _, status := range statuses {
+		if _, ok := seen[status]; ok {
+			t.Fatalf("duplicate Status detected: %q", status)
+		}
+		seen[status] = struct{}{}
+	}
+}
+
+func TestFormats_AreNonEmpty_When_InteractingAcrossPackages(t *testing.T) {
+	t.Parallel()
+
+	items := []struct {
+		name string
+		kind string
+	}{
+		{name: "summary kind sarif", kind: string(pattern.SummaryKindSARIF)},
+		{name: "summary kind test", kind: string(pattern.SummaryKindTest)},
+		{name: "summary kind report", kind: string(pattern.SummaryKindReport)},
+		{name: "item success", kind: string(pattern.KindSuccess)},
+		{name: "item error", kind: string(pattern.KindError)},
+		{name: "item warning", kind: string(pattern.KindWarning)},
+		{name: "item info", kind: string(pattern.KindInfo)},
+		{name: "status pass", kind: string(pattern.StatusPass)},
+		{name: "status fail", kind: string(pattern.StatusFail)},
+		{name: "status skip", kind: string(pattern.StatusSkip)},
+	}
+
+	for _, tt := range items {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if tt.kind == "" {
+				t.Fatalf("%s must be non-empty", tt.name)
+			}
+		})
+	}
+}

--- a/pkg/wrapper/registry_external_test.go
+++ b/pkg/wrapper/registry_external_test.go
@@ -1,0 +1,85 @@
+package wrapper_test
+
+import (
+	"io"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/dkoosis/fo/pkg/wrapper"
+)
+
+type fakeWrapper struct {
+	format wrapper.Format
+}
+
+func (f fakeWrapper) OutputFormat() wrapper.Format                    { return f.format }
+func (f fakeWrapper) Wrap(_ []string, _ io.Reader, _ io.Writer) error { return nil }
+
+func TestRegistry_Get_ReturnsNil_When_NameIsUnknown(t *testing.T) {
+	if got := wrapper.Get("__missing_wrapper_name__"); got != nil {
+		t.Fatalf("Get(unknown) = %T, want nil", got)
+	}
+}
+
+func TestRegistry_Register_ReturnsRegisteredWrapper_When_NameExists(t *testing.T) {
+	// Registry is process-global mutable state. Keep this test non-parallel.
+	name := "test-wrapper-register-contract"
+	want := fakeWrapper{format: wrapper.FormatSARIF}
+	wrapper.Register(name, want)
+
+	got := wrapper.Get(name)
+	if got == nil {
+		t.Fatalf("Get(%q) = nil, want registered wrapper", name)
+	}
+	if got.OutputFormat() != wrapper.FormatSARIF {
+		t.Fatalf("Get(%q).OutputFormat() = %q, want %q", name, got.OutputFormat(), wrapper.FormatSARIF)
+	}
+}
+
+func TestRegistry_Register_ReplacesExistingWrapper_When_NameAlreadyRegistered(t *testing.T) {
+	// Registry is process-global mutable state. Keep this test non-parallel.
+	name := "test-wrapper-overwrite-contract"
+	wrapper.Register(name, fakeWrapper{format: wrapper.FormatSARIF})
+	wrapper.Register(name, fakeWrapper{format: wrapper.FormatTestJSON})
+
+	got := wrapper.Get(name)
+	if got == nil {
+		t.Fatalf("Get(%q) = nil, want updated wrapper", name)
+	}
+	if got.OutputFormat() != wrapper.FormatTestJSON {
+		t.Fatalf("OutputFormat() = %q, want %q", got.OutputFormat(), wrapper.FormatTestJSON)
+	}
+}
+
+func TestRegistry_Names_ReturnsSortedNames_When_RegistryContainsMultipleEntries(t *testing.T) {
+	// Registry is process-global mutable state. Keep this test non-parallel.
+	for _, name := range []string{
+		"test-wrapper-sort-c",
+		"test-wrapper-sort-a",
+		"test-wrapper-sort-b",
+	} {
+		wrapper.Register(name, fakeWrapper{format: wrapper.FormatSARIF})
+	}
+
+	names := wrapper.Names()
+	if !sort.StringsAreSorted(names) {
+		t.Fatalf("Names() not sorted: %v", names)
+	}
+
+	var gotSubset []string
+	for _, name := range names {
+		if strings.HasPrefix(name, "test-wrapper-sort-") {
+			gotSubset = append(gotSubset, name)
+		}
+	}
+	wantSubset := []string{"test-wrapper-sort-a", "test-wrapper-sort-b", "test-wrapper-sort-c"}
+	if len(gotSubset) != len(wantSubset) {
+		t.Fatalf("subset size = %d, want %d (%v)", len(gotSubset), len(wantSubset), gotSubset)
+	}
+	for i := range wantSubset {
+		if gotSubset[i] != wantSubset[i] {
+			t.Fatalf("subset[%d] = %q, want %q (subset=%v)", i, gotSubset[i], wantSubset[i], gotSubset)
+		}
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide safety-net tests that assert public contract invariants for `pkg/pattern` and `pkg/wrapper` so future refactors are safe.
- Prefer external test packages to exercise exported surface and avoid coupling to implementation details.

### Description
- Add `pkg/pattern/pattern_external_test.go` with table-driven external tests that assert stable `Type()` values, distinct `SummaryKind` and `Status` constants, and that exported kind/status string values are non-empty.
- Add `pkg/wrapper/registry_external_test.go` which provides a `fakeWrapper` and tests registry behavior: unknown-name `Get` returns `nil`, `Register`/`Get` round-trip, overwrite semantics when re-registering the same name, and that `Names()` returns a sorted list; tests intentionally avoid parallelization where registry global state is mutated.
- Apply standard formatting/import fixes to the new test files to match repository style.

### Testing
- Ran `go test ./pkg/pattern ./pkg/wrapper` and both packages passed.
- Ran `go test -race -short ./...` and the test suite completed successfully (some packages cached).
- Ran `make qa` which executed build/test/vet/lint and failed on an existing linter finding (`pkg/stream/stream.go:245` prealloc suggestion) unrelated to these new tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7c0d5309883258332a4f781e7bede)