### PR TITLE
test(pattern): add invariant-focused contract tests for pattern package

### DIFF
--- a/pkg/pattern/pattern_test.go
+++ b/pkg/pattern/pattern_test.go
@@ -1,0 +1,183 @@
+package pattern_test
+
+import (
+	"testing"
+
+	"github.com/dkoosis/fo/pkg/pattern"
+)
+
+func TestPatternType_ReturnsExpectedContractValue_WhenUsingKnownPatternConstants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		got  pattern.PatternType
+		want string
+	}{
+		{name: "summary", got: pattern.PatternTypeSummary, want: "summary"},
+		{name: "leaderboard", got: pattern.PatternTypeLeaderboard, want: "leaderboard"},
+		{name: "test-table", got: pattern.PatternTypeTestTable, want: "test-table"},
+		{name: "error", got: pattern.PatternTypeError, want: "error"},
+	}
+
+	seen := map[pattern.PatternType]bool{}
+	for _, tt := range tests {
+		if seen[tt.got] {
+			t.Fatalf("PatternType %q duplicated in contract table", tt.got)
+		}
+		seen[tt.got] = true
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if string(tt.got) != tt.want {
+				t.Fatalf("PatternType constant mismatch: got %q want %q", tt.got, tt.want)
+			}
+			if tt.got == "" {
+				t.Fatal("PatternType should never be empty")
+			}
+		})
+	}
+}
+
+func TestPatternType_ReturnsExpectedType_WhenPatternImplementsInterface(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   pattern.Pattern
+		want pattern.PatternType
+	}{
+		{name: "error pointer", in: &pattern.Error{}, want: pattern.PatternTypeError},
+		{name: "summary pointer", in: &pattern.Summary{}, want: pattern.PatternTypeSummary},
+		{name: "leaderboard pointer", in: &pattern.Leaderboard{}, want: pattern.PatternTypeLeaderboard},
+		{name: "test table pointer", in: &pattern.TestTable{}, want: pattern.PatternTypeTestTable},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if tt.in == nil {
+				t.Fatal("test setup error: pattern must not be nil")
+			}
+
+			got := tt.in.Type()
+			if got != tt.want {
+				t.Fatalf("Type() mismatch: got %q want %q", got, tt.want)
+			}
+			if got == "" {
+				t.Fatal("Type() should never return empty pattern type")
+			}
+		})
+	}
+}
+
+func TestPatternType_DoesNotPanic_WhenTypeCalledOnNilReceiver(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   pattern.Pattern
+		want pattern.PatternType
+	}{
+		{name: "nil error", in: (*pattern.Error)(nil), want: pattern.PatternTypeError},
+		{name: "nil summary", in: (*pattern.Summary)(nil), want: pattern.PatternTypeSummary},
+		{name: "nil leaderboard", in: (*pattern.Leaderboard)(nil), want: pattern.PatternTypeLeaderboard},
+		{name: "nil test table", in: (*pattern.TestTable)(nil), want: pattern.PatternTypeTestTable},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.in.Type(); got != tt.want {
+				t.Fatalf("nil receiver Type() mismatch: got %q want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSummaryKind_ReturnsExpectedContractValue_WhenUsingKnownSummaryKindConstants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		got  pattern.SummaryKind
+		want string
+	}{
+		{name: "sarif", got: pattern.SummaryKindSARIF, want: "sarif"},
+		{name: "test", got: pattern.SummaryKindTest, want: "test"},
+		{name: "report", got: pattern.SummaryKindReport, want: "report"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if string(tt.got) != tt.want {
+				t.Fatalf("SummaryKind constant mismatch: got %q want %q", tt.got, tt.want)
+			}
+			if tt.got == "" {
+				t.Fatal("SummaryKind should never be empty")
+			}
+		})
+	}
+}
+
+func TestItemKind_ReturnsExpectedContractValue_WhenUsingKnownItemKindConstants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		got  pattern.ItemKind
+		want string
+	}{
+		{name: "success", got: pattern.KindSuccess, want: "success"},
+		{name: "error", got: pattern.KindError, want: "error"},
+		{name: "warning", got: pattern.KindWarning, want: "warning"},
+		{name: "info", got: pattern.KindInfo, want: "info"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if string(tt.got) != tt.want {
+				t.Fatalf("ItemKind constant mismatch: got %q want %q", tt.got, tt.want)
+			}
+			if tt.got == "" {
+				t.Fatal("ItemKind should never be empty")
+			}
+		})
+	}
+}
+
+func TestStatus_ReturnsExpectedContractValue_WhenUsingKnownStatusConstants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		got  pattern.Status
+		want string
+	}{
+		{name: "pass", got: pattern.StatusPass, want: "pass"},
+		{name: "fail", got: pattern.StatusFail, want: "fail"},
+		{name: "skip", got: pattern.StatusSkip, want: "skip"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if string(tt.got) != tt.want {
+				t.Fatalf("Status constant mismatch: got %q want %q", tt.got, tt.want)
+			}
+			if tt.got == "" {
+				t.Fatal("Status should never be empty")
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide safety-net tests that assert public contract invariants for pattern types and prevent regressions when refactoring public constants and `Type()` behavior.
- Ensure nil-receiver safety and stable wire/string values for exported enums used by renderers and dispatch logic.

### Description
- Add a new external-package test file at `pkg/pattern/pattern_test.go` containing table-driven tests with ADR-008-compliant names that validate `PatternType`, `SummaryKind`, `ItemKind`, and `Status` constant string values.
- Add tests that exercise `Type()` on concrete implementations (`Error`, `Summary`, `Leaderboard`, `TestTable`) and validate nil-receiver safety to catch potential panics.
- Add invariant checks for non-empty constant values and a uniqueness check for `PatternType` entries.
- No production code was modified; this change only adds tests and formatting updates were applied with `gofumpt`/`goimports`.

### Testing
- Ran `go test -race -short ./pkg/pattern ./...` and the new package tests passed (`ok github.com/dkoosis/fo/pkg/pattern`).
- Ran full test and coverage with `go test -coverprofile=coverage.out ./...` and package coverage for `pkg/pattern` is now reported at 100% while overall coverage remains unchanged for other packages.
- Ran formatting (`gofumpt -w` and `goimports -w`) and unit tests; these succeeded for the added tests.
- Ran `make qa`, which executed builds and tests but failed the lint step due to an existing lint warning in unrelated code at `pkg/stream/stream.go:257:2` (`prealloc`), so the repository-wide QA target did not fully succeed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c911d59b148325a53d2028e2141944)