### PR TITLE
test: add golden help snapshots for fo CLI

### DIFF
--- a/cmd/fo/help_golden_test.go
+++ b/cmd/fo/help_golden_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func executeCommand(args ...string) (stdout, stderr string, err error) {
+	var outBuf, errBuf bytes.Buffer
+	code := run(args, bytes.NewReader(nil), &outBuf, &errBuf)
+	if code != 0 {
+		return outBuf.String(), errBuf.String(), &exitError{code: code}
+	}
+	return outBuf.String(), errBuf.String(), nil
+}
+
+type exitError struct{ code int }
+
+func (e *exitError) Error() string { return "non-zero exit" }
+
+type helpNode struct {
+	name     string
+	args     []string
+	visible  bool
+	children []helpNode
+}
+
+func walkVisibleHelp(nodes []helpNode, visit func(name string, args []string)) {
+	var walk func(prefixName string, n helpNode)
+	walk = func(prefixName string, n helpNode) {
+		fullName := strings.TrimSpace(strings.TrimSpace(prefixName + " " + n.name))
+		if n.visible {
+			path := append(append([]string{}, n.args...), "--help")
+			visit(fullName, path)
+		}
+		for _, ch := range n.children {
+			walk(fullName, ch)
+		}
+	}
+	for _, n := range nodes {
+		walk("", n)
+	}
+}
+
+func normalizeHelp(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	lines := strings.Split(s, "\n")
+	for i := range lines {
+		lines[i] = strings.TrimRight(lines[i], " \t")
+	}
+	out := strings.Join(lines, "\n")
+	out = strings.TrimRight(out, "\n")
+	return out + "\n"
+}
+
+func readGolden(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden %s: %v", path, err)
+	}
+	return string(b)
+}
+
+func writeGolden(path, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+func goldenName(name string) string {
+	if name == "root" {
+		return "root.golden"
+	}
+	return strings.ReplaceAll(name, " ", "-") + ".golden"
+}
+
+func TestHelpGolden(t *testing.T) {
+	commands := []helpNode{{
+		name:    "root",
+		args:    nil,
+		visible: true,
+		children: []helpNode{{
+			name:    "wrap",
+			args:    []string{"wrap"},
+			visible: true,
+			children: []helpNode{
+				{name: "archlint", args: []string{"wrap", "archlint"}, visible: true},
+				{name: "diag", args: []string{"wrap", "diag"}, visible: true},
+				{name: "jscpd", args: []string{"wrap", "jscpd"}, visible: true},
+			},
+		}},
+	}}
+
+	walkVisibleHelp(commands, func(name string, args []string) {
+		t.Run(name, func(t *testing.T) {
+			stdout, stderr, err := executeCommand(args...)
+			if err != nil {
+				t.Fatalf("run %q: %v (stderr=%q)", strings.Join(args, " "), err, stderr)
+			}
+			got := normalizeHelp(stdout + stderr)
+			goldenPath := filepath.Join("testdata", "help", goldenName(name))
+			if *update {
+				if err := writeGolden(goldenPath, got); err != nil {
+					t.Fatalf("write golden %s: %v", goldenPath, err)
+				}
+				return
+			}
+			want := normalizeHelp(readGolden(t, goldenPath))
+			if got != want {
+				t.Fatalf("help output mismatch for %s\n--- want ---\n%s\n--- got ---\n%s", name, want, got)
+			}
+		})
+	})
+}

--- a/cmd/fo/testdata/help/root-wrap-archlint.golden
+++ b/cmd/fo/testdata/help/root-wrap-archlint.golden
@@ -1,0 +1,1 @@
+Usage of fo wrap archlint:

--- a/cmd/fo/testdata/help/root-wrap-diag.golden
+++ b/cmd/fo/testdata/help/root-wrap-diag.golden
@@ -1,0 +1,9 @@
+Usage of fo wrap diag:
+  -level string
+    	Default severity: error|warning|note (default "warning")
+  -rule string
+    	Default rule ID (default "finding")
+  -tool string
+    	Tool name for SARIF driver.name (required)
+  -version string
+    	Tool version string

--- a/cmd/fo/testdata/help/root-wrap-jscpd.golden
+++ b/cmd/fo/testdata/help/root-wrap-jscpd.golden
@@ -1,0 +1,1 @@
+Usage of fo wrap jscpd:

--- a/cmd/fo/testdata/help/root-wrap.golden
+++ b/cmd/fo/testdata/help/root-wrap.golden
@@ -1,0 +1,11 @@
+fo wrap: convert tool output to SARIF
+
+  archlint     Convert go-arch-lint JSON to SARIF
+  diag         Convert line diagnostics (file:line:col: msg) to SARIF
+  jscpd        Convert jscpd JSON duplication report to SARIF
+
+  diag flags:
+    --tool <name>     Tool name for SARIF driver.name (required)
+    --rule <id>       Default rule ID (default: finding)
+    --level <sev>     Default severity: error|warning|note (default: warning)
+    --version <ver>   Tool version string

--- a/cmd/fo/testdata/help/root.golden
+++ b/cmd/fo/testdata/help/root.golden
@@ -1,0 +1,30 @@
+fo — focused build output renderer
+
+USAGE
+  <input-command> | fo [FLAGS]
+  <tool-output>   | fo wrap <name> [FLAGS]
+
+INPUT FORMATS (auto-detected from stdin)
+  SARIF 2.1.0     Static analysis results (golangci-lint, gosec, etc.)
+  go test -json   Test execution stream
+
+OUTPUT FORMATS (--format)
+  auto            TTY → human, piped → llm (default)
+  human           Tufte-Swiss styled terminal output
+  llm             Token-dense plain text, no ANSI
+  json            Machine-parseable Report JSON
+
+FLAGS
+  --format <mode>     auto | human | llm | json (default: auto)
+  --theme <name>      color | mono (default: auto — color on TTY, mono otherwise)
+  --state-file <path> Sidecar state file (default: .fo/last-run.json)
+  --no-state          Skip diff classification and sidecar I/O
+
+SUBCOMMANDS
+  fo wrap <name>     Convert tool output to SARIF
+  fo wrap --help     Show available wrappers
+
+EXIT CODES
+  0   Clean — no errors or test failures
+  1   Failures — lint errors or test failures present
+  2   Usage error — bad flags, unrecognized input, stdin problems


### PR DESCRIPTION
### Motivation
- Provide a minimal, maintainable golden-test harness that snapshots the `--help` output for the `fo` CLI so the public command/flag surface is reviewable and stable.
- Target a single utility (the `fo` command) without introducing repo-wide refactors or changing runtime behavior, using the existing `run(args, stdin, stdout, stderr)` entrypoint because the project does not use Cobra.

### Description
- Add `cmd/fo/help_golden_test.go` which implements `executeCommand`, a visible-command walker, `normalizeHelp`, golden read/write helpers, and a `-update` flag for regenerating snapshots.
- Capture help output for the visible command paths `root`, `wrap`, `wrap archlint`, `wrap diag`, and `wrap jscpd`, and place fixtures under `cmd/fo/testdata/help/*.golden`.
- The harness invokes the existing `run` function (no CLI behavior changed) and normalizes CRLF → LF, trims trailing whitespace per line, and ensures exactly one trailing newline before comparing goldens.
- No production code was modified; only tests and testdata were added.

### Testing
- Ran `go test ./cmd/fo -update` to generate the golden files, which completed successfully and created `cmd/fo/testdata/help/*.golden`.
- Ran `go test ./...` which completed successfully across the repository.
- Ran `go test ./... -update` which fails in non-`cmd/fo` packages because the `-update` flag is only defined in the `cmd/fo` test binary, and this behavior is expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0dc8ce05c8325be3d647ee9ad7c64)