### PR TITLE
fix(lint): resolve modernize and nestif lint failures

### DIFF
--- a/.claude/rules/boot.md
+++ b/.claude/rules/boot.md
@@ -1,7 +1,8 @@
 # Boot
 updated: 2026-04-29
 
-→ `bd ready` — pick next true-bug audit finding (fo-frl P1, fo-y2o P2, fo-4qh P2 all open)
+→ `bd ready` — only fo-4un (decision bead) remains; rest is dk-pick
 
 ✓ done
-- fo-9js shipped: state.Save errors → Report.Notices + --state-strict; LLM/JSON visible
+- fo-odj: BUILD FAILED / PANIC headlines carry compile error + user-code frame
+- fo-6gt: LLM mode bypasses leaderboard/small-multiples → finding list w/ file:line

--- a/pkg/testjson/parser.go
+++ b/pkg/testjson/parser.go
@@ -285,18 +285,18 @@ func (*aggregator) handleFail(pkg *pkgState, e TestEvent) {
 	if e.Test != "" {
 		pkg.failed++
 		pkg.failedOrder = append(pkg.failedOrder, e.Test)
-	} else {
-		pkg.duration = time.Duration(e.Elapsed * float64(time.Second))
-		// Check if this is a build error (failed with no tests run).
-		// Prefer compiler output collected from build-output events; fall
-		// back to package-level output for older streams that don't carry
-		// the build-output action.
-		if pkg.passed == 0 && pkg.failed == 0 && pkg.skipped == 0 && pkg.buildError == "" {
-			if len(pkg.buildOutput) > 0 {
-				pkg.buildError = strings.Join(pkg.buildOutput, "\n")
-			} else {
-				pkg.buildError = strings.Join(pkg.outputBuf[""], "\n")
-			}
+		return
+	}
+	pkg.duration = time.Duration(e.Elapsed * float64(time.Second))
+	// Check if this is a build error (failed with no tests run).
+	// Prefer compiler output collected from build-output events; fall
+	// back to package-level output for older streams that don't carry
+	// the build-output action.
+	if pkg.passed == 0 && pkg.failed == 0 && pkg.skipped == 0 && pkg.buildError == "" {
+		if len(pkg.buildOutput) > 0 {
+			pkg.buildError = strings.Join(pkg.buildOutput, "\n")
+		} else {
+			pkg.buildError = strings.Join(pkg.outputBuf[""], "\n")
 		}
 	}
 }

--- a/pkg/view/headline.go
+++ b/pkg/view/headline.go
@@ -1,22 +1,27 @@
 package view
 
 import (
+	"strings"
+
 	"github.com/dkoosis/fo/pkg/report"
 	"github.com/dkoosis/fo/pkg/theme"
 )
 
 func renderHeadline(v Headline, t theme.Theme) string {
-	out := t.Heading.Render(v.Title)
+	var b strings.Builder
+	b.WriteString(t.Heading.Render(v.Title))
 	if v.Detail != "" {
-		out += "\n" + t.Muted.Render(v.Detail)
+		b.WriteString("\n")
+		b.WriteString(t.Muted.Render(v.Detail))
 	}
 	for _, line := range v.Body {
 		if line == "" {
 			continue
 		}
-		out += "\n" + t.Muted.Render(line)
+		b.WriteString("\n")
+		b.WriteString(t.Muted.Render(line))
 	}
-	return out
+	return b.String()
 }
 
 func renderAlert(v Alert, t theme.Theme) string {

--- a/pkg/view/pickview.go
+++ b/pkg/view/pickview.go
@@ -178,7 +178,7 @@ func stripFramePC(s string) string {
 // buildErrorBody returns the first non-empty line of build output —
 // typically "file:line:col: msg", which is what the user needs to fix.
 func buildErrorBody(output string) []string {
-	for _, ln := range strings.Split(output, "\n") {
+	for ln := range strings.SplitSeq(output, "\n") {
 		trim := strings.TrimSpace(ln)
 		if trim == "" || strings.HasPrefix(trim, "# ") {
 			continue


### PR DESCRIPTION
## Summary

- `pkg/view/headline.go`: replace `+=` string concat in loop with `strings.Builder` (modernize/stringsbuilder)
- `pkg/view/pickview.go`: switch `strings.Split` to `strings.SplitSeq` in range loop (modernize/stringsseq)
- `pkg/testjson/parser.go`: early return in `handleFail` to flatten if/else nesting (nestif complexity 5→4)

## Test plan

- [x] `make audit` passes clean (0 lint issues, all tests green, race detector clean)