### PR TITLE
lint: enable gocritic rangeValCopy + fix 2 sites

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -108,7 +108,6 @@ linters:
         - deprecatedComment
         - hugeParam
         - ifElseChain
-        - rangeValCopy
         - unlambda
     cyclop:
       max-complexity: 15

--- a/pkg/testjson/stats.go
+++ b/pkg/testjson/stats.go
@@ -19,7 +19,8 @@ type Stats struct {
 func ComputeStats(results []TestPackageResult) Stats {
 	var s Stats
 	s.Packages = len(results)
-	for _, r := range results {
+	for i := range results {
+		r := &results[i]
 		s.Passed += r.Passed
 		s.Failed += r.Failed
 		s.Skipped += r.Skipped

--- a/pkg/testjson/toreport.go
+++ b/pkg/testjson/toreport.go
@@ -25,7 +25,8 @@ func ToReport(results []TestPackageResult) *report.Report {
 		GeneratedAt: time.Now().UTC(),
 	}
 
-	for _, pkg := range results {
+	for i := range results {
+		pkg := &results[i]
 		switch {
 		case pkg.Panicked:
 			out := strings.Join(pkg.PanicOutput, "\n")


### PR DESCRIPTION
128-byte TestPackageResult copies in range loops. Switched to index+pointer iteration. Sibling PR in trixi/loto.