### PR TITLE
scene: # fo:scene parser (fo-fl0.1)

### DIFF
--- a/pkg/scene/scene.go
+++ b/pkg/scene/scene.go
@@ -1,0 +1,394 @@
+// Package scene parses fo's scene input format — narrated, multi-actor
+// walk-throughs grouped into numbered acts. Used by tools like loto's
+// `make demo` to ship a polished transcript as the primary deliverable
+// rather than `go test -v` framing.
+//
+// Format:
+//
+//	# fo:scene [title=<string>] [actors=<csv>]
+//	## <act-number> · <act-title>
+//	> <narration line>
+//	@<actor> $ <command>
+//	  <output line>
+//	  (exit <N>)
+//
+// Rules:
+//   - `>` lines are narration beats; preserved text is what follows `> `.
+//   - `@actor $ cmd` opens a command beat. Subsequent lines indented by
+//     exactly two spaces are captured output. The first non-indented or
+//     differently-shaped line ends the command. An `(exit N)` line, if
+//     present as the last indented line, sets Command.Exit; default 0.
+//   - Blank lines inside an act separate beats. Blank lines before the
+//     first `##` are ignored.
+//   - `#` comment lines after the header (not the header itself) are
+//     ignored.
+//
+// Grammar note: an output line that itself looks like `  (exit N)` is
+// treated as the exit trailer iff it is the final indented line of the
+// command's run. Other parenthesized indented lines are kept verbatim
+// in Output. Lines with non-2-space indentation (tab, single space,
+// 3+ spaces) terminate the command.
+package scene
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+const HeaderPrefix = "# fo:scene"
+
+// BeatKind discriminates the Beat union.
+type BeatKind int
+
+const (
+	BeatNarration BeatKind = iota
+	BeatCommand
+)
+
+// Beat is one narrative or command unit inside an Act.
+type Beat struct {
+	Kind      BeatKind `json:"kind"`
+	Narration string   `json:"narration,omitempty"`
+	Command   Command  `json:"command,omitzero"`
+}
+
+// Command is an invocation beat: `@actor $ cmd` plus output and exit.
+type Command struct {
+	Actor  string   `json:"actor"`
+	Cmd    string   `json:"cmd"`
+	Output []string `json:"output,omitempty"`
+	Exit   int      `json:"exit"`
+}
+
+// Act groups beats under a numbered title.
+type Act struct {
+	Number string `json:"number"`
+	Title  string `json:"title"`
+	Beats  []Beat `json:"beats,omitempty"`
+}
+
+// Scene is a parsed `# fo:scene` document.
+type Scene struct {
+	Title  string   `json:"title,omitempty"`
+	Actors []string `json:"actors,omitempty"`
+	Acts   []Act    `json:"acts,omitempty"`
+}
+
+// IsHeader reports whether data starts (modulo leading whitespace and
+// blank lines) with the scene header prefix.
+func IsHeader(data []byte) bool {
+	s := string(data)
+	for {
+		nl := strings.IndexByte(s, '\n')
+		var line string
+		if nl < 0 {
+			line = s
+			s = ""
+		} else {
+			line = s[:nl]
+			s = s[nl+1:]
+		}
+		trimmed := strings.TrimLeft(line, " \t\r")
+		if trimmed == "" {
+			if nl < 0 {
+				return false
+			}
+			continue
+		}
+		return strings.HasPrefix(trimmed, HeaderPrefix)
+	}
+}
+
+var (
+	ErrNoHeader       = errors.New("scene: missing '# fo:scene' header")
+	ErrMalformedAct   = errors.New("scene: malformed act header")
+	ErrMalformedActor = errors.New("scene: malformed actor line")
+	ErrMalformedExit  = errors.New("scene: malformed exit trailer")
+	ErrUnknownAttr    = errors.New("scene: unknown header attr")
+)
+
+// Parse reads a scene document from r.
+func Parse(r io.Reader) (Scene, error) {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 64*1024), 1<<20)
+
+	p := &parser{}
+	for sc.Scan() {
+		p.lineNo++
+		if err := p.feed(sc.Text()); err != nil {
+			return Scene{}, err
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return Scene{}, fmt.Errorf("scene: read: %w", err)
+	}
+	p.flushCmd()
+	if !p.headerSeen {
+		return Scene{}, ErrNoHeader
+	}
+	return p.s, nil
+}
+
+type parser struct {
+	s          Scene
+	headerSeen bool
+	lineNo     int
+	curAct     *Act
+	curCmd     *Command
+}
+
+func (p *parser) flushCmd() {
+	if p.curCmd == nil {
+		return
+	}
+	p.curAct.Beats = append(p.curAct.Beats, Beat{Kind: BeatCommand, Command: *p.curCmd})
+	p.curCmd = nil
+}
+
+func (p *parser) feed(raw string) error {
+	if !p.headerSeen {
+		return p.feedHeader(raw)
+	}
+	if p.curCmd != nil && isOutputLine(raw) {
+		return p.feedOutput(raw[2:])
+	}
+	p.flushCmd()
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil
+	}
+	return p.feedBody(trimmed)
+}
+
+func (p *parser) feedHeader(raw string) error {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil
+	}
+	if !strings.HasPrefix(trimmed, HeaderPrefix) {
+		return ErrNoHeader
+	}
+	rest := strings.TrimSpace(strings.TrimPrefix(trimmed, HeaderPrefix))
+	if err := parseHeaderAttrs(rest, &p.s); err != nil {
+		return fmt.Errorf("scene: line %d: %w", p.lineNo, err)
+	}
+	p.headerSeen = true
+	return nil
+}
+
+func (p *parser) feedOutput(body string) error {
+	exit, ok, err := parseExitTrailer(body)
+	if err != nil {
+		return fmt.Errorf("scene: line %d: %w", p.lineNo, err)
+	}
+	if ok {
+		p.curCmd.Exit = exit
+		p.flushCmd()
+		return nil
+	}
+	p.curCmd.Output = append(p.curCmd.Output, body)
+	return nil
+}
+
+func (p *parser) feedBody(trimmed string) error {
+	switch {
+	case strings.HasPrefix(trimmed, "## "):
+		act, err := parseActHeader(trimmed)
+		if err != nil {
+			return fmt.Errorf("scene: line %d: %w", p.lineNo, err)
+		}
+		p.s.Acts = append(p.s.Acts, act)
+		p.curAct = &p.s.Acts[len(p.s.Acts)-1]
+		return nil
+	case strings.HasPrefix(trimmed, "#"):
+		return nil
+	case strings.HasPrefix(trimmed, "> ") || trimmed == ">":
+		if p.curAct == nil {
+			return fmt.Errorf("scene: line %d: %w: narration before any act", p.lineNo, ErrMalformedAct)
+		}
+		text := strings.TrimPrefix(strings.TrimPrefix(trimmed, ">"), " ")
+		p.curAct.Beats = append(p.curAct.Beats, Beat{Kind: BeatNarration, Narration: text})
+		return nil
+	case strings.HasPrefix(trimmed, "@"):
+		if p.curAct == nil {
+			return fmt.Errorf("scene: line %d: %w: command before any act", p.lineNo, ErrMalformedActor)
+		}
+		cmd, err := parseActorLine(trimmed)
+		if err != nil {
+			return fmt.Errorf("scene: line %d: %w", p.lineNo, err)
+		}
+		p.curCmd = &cmd
+		return nil
+	}
+	return fmt.Errorf("scene: line %d: %w: %q", p.lineNo, ErrMalformedAct, trimmed)
+}
+
+func isOutputLine(raw string) bool {
+	if len(raw) < 2 {
+		return false
+	}
+	if raw[0] != ' ' || raw[1] != ' ' {
+		return false
+	}
+	// reject 3+ leading spaces or tab indent (terminates command).
+	if len(raw) >= 3 && raw[2] == ' ' {
+		return false
+	}
+	return true
+}
+
+func parseExitTrailer(body string) (int, bool, error) {
+	t := strings.TrimSpace(body)
+	if !strings.HasPrefix(t, "(exit") || !strings.HasSuffix(t, ")") {
+		return 0, false, nil
+	}
+	inner := strings.TrimSuffix(strings.TrimPrefix(t, "(exit"), ")")
+	inner = strings.TrimSpace(inner)
+	if inner == "" {
+		return 0, false, fmt.Errorf("%w: missing exit code in %q", ErrMalformedExit, body)
+	}
+	n, err := strconv.Atoi(inner)
+	if err != nil {
+		return 0, false, fmt.Errorf("%w: %q", ErrMalformedExit, inner)
+	}
+	return n, true, nil
+}
+
+func parseActHeader(line string) (Act, error) {
+	rest := strings.TrimSpace(strings.TrimPrefix(line, "##"))
+	// expect: N · title (middle-dot separator)
+	numTok, titleTok, ok := strings.Cut(rest, "·")
+	if !ok {
+		return Act{}, fmt.Errorf("%w: expected 'N · title', got %q", ErrMalformedAct, line)
+	}
+	number := strings.TrimSpace(numTok)
+	title := strings.TrimSpace(titleTok)
+	if number == "" || title == "" {
+		return Act{}, fmt.Errorf("%w: empty number or title in %q", ErrMalformedAct, line)
+	}
+	return Act{Number: number, Title: title}, nil
+}
+
+func parseActorLine(line string) (Command, error) {
+	// `@actor $ cmd` — actor has no whitespace; `$` separates command.
+	rest := strings.TrimPrefix(line, "@")
+	sp := strings.IndexAny(rest, " \t")
+	if sp <= 0 {
+		return Command{}, fmt.Errorf("%w: expected '@actor $ cmd', got %q", ErrMalformedActor, line)
+	}
+	actor := rest[:sp]
+	tail := strings.TrimLeft(rest[sp:], " \t")
+	if !strings.HasPrefix(tail, "$") {
+		return Command{}, fmt.Errorf("%w: missing '$' after actor in %q", ErrMalformedActor, line)
+	}
+	cmd := strings.TrimLeft(strings.TrimPrefix(tail, "$"), " \t")
+	if cmd == "" {
+		return Command{}, fmt.Errorf("%w: empty command in %q", ErrMalformedActor, line)
+	}
+	return Command{Actor: actor, Cmd: cmd}, nil
+}
+
+func parseHeaderAttrs(tail string, s *Scene) error {
+	toks, err := tokenizeAttrs(tail)
+	if err != nil {
+		return err
+	}
+	for _, tok := range toks {
+		if err := applyAttr(tok, s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applyAttr(tok string, s *Scene) error {
+	key, val, ok := strings.Cut(tok, "=")
+	if !ok || key == "" {
+		return fmt.Errorf("%w: expected key=value, got %q", ErrUnknownAttr, tok)
+	}
+	switch strings.ToLower(key) {
+	case "title":
+		s.Title = val
+	case "actors":
+		for a := range strings.SplitSeq(val, ",") {
+			if t := strings.TrimSpace(a); t != "" {
+				s.Actors = append(s.Actors, t)
+			}
+		}
+	default:
+		return fmt.Errorf("%w: %q", ErrUnknownAttr, key)
+	}
+	return nil
+}
+
+// tokenizeAttrs splits on whitespace, honoring double-quoted values
+// after `=`. Quote-aware; mirrors pkg/suppress conventions.
+func tokenizeAttrs(line string) ([]string, error) {
+	var toks []string
+	var cur strings.Builder
+	st := attrTokState{}
+	for i := range len(line) {
+		if err := st.step(line[i], &cur, &toks); err != nil {
+			return nil, err
+		}
+	}
+	if st.inQuote {
+		return nil, fmt.Errorf("%w: unclosed quote in header", ErrUnknownAttr)
+	}
+	if cur.Len() > 0 {
+		toks = append(toks, cur.String())
+	}
+	return toks, nil
+}
+
+type attrTokState struct {
+	inQuote bool
+	escape  bool
+}
+
+func (st *attrTokState) step(c byte, cur *strings.Builder, toks *[]string) error {
+	if st.escape {
+		cur.WriteByte(c)
+		st.escape = false
+		return nil
+	}
+	if st.inQuote {
+		return st.stepInQuote(c, cur)
+	}
+	return st.stepBare(c, cur, toks)
+}
+
+func (st *attrTokState) stepInQuote(c byte, cur *strings.Builder) error {
+	switch c {
+	case '\\':
+		st.escape = true
+	case '"':
+		st.inQuote = false
+	default:
+		cur.WriteByte(c)
+	}
+	return nil
+}
+
+func (st *attrTokState) stepBare(c byte, cur *strings.Builder, toks *[]string) error {
+	switch c {
+	case ' ', '\t':
+		if cur.Len() > 0 {
+			*toks = append(*toks, cur.String())
+			cur.Reset()
+		}
+	case '"':
+		s := cur.String()
+		if len(s) == 0 || s[len(s)-1] != '=' {
+			return fmt.Errorf("%w: stray '\"' in header", ErrUnknownAttr)
+		}
+		st.inQuote = true
+	default:
+		cur.WriteByte(c)
+	}
+	return nil
+}

--- a/pkg/scene/scene.go
+++ b/pkg/scene/scene.go
@@ -145,6 +145,15 @@ func (p *parser) flushCmd() {
 	if p.curCmd == nil {
 		return
 	}
+	// The exit trailer is only a trailer if it's the FINAL indented
+	// line of the command block. Detect it here at flush time so an
+	// `(exit N)` appearing mid-output is treated as literal output.
+	if n := len(p.curCmd.Output); n > 0 {
+		if exit, ok, err := parseExitTrailer(p.curCmd.Output[n-1]); err == nil && ok {
+			p.curCmd.Exit = exit
+			p.curCmd.Output = p.curCmd.Output[:n-1]
+		}
+	}
 	p.curAct.Beats = append(p.curAct.Beats, Beat{Kind: BeatCommand, Command: *p.curCmd})
 	p.curCmd = nil
 }

--- a/pkg/scene/scene_test.go
+++ b/pkg/scene/scene_test.go
@@ -1,0 +1,192 @@
+package scene
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestIsHeader(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"# fo:scene\n", true},
+		{"# fo:scene title=\"x\" actors=A,B\n## 01 · t\n", true},
+		{"\n\n  # fo:scene\n", true},
+		{"# fo:status\n", false},
+		{"## 01 · t\n", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := IsHeader([]byte(c.in)); got != c.want {
+			t.Errorf("IsHeader(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParse_happy(t *testing.T) {
+	in := `# fo:scene title="loto demo" actors=FrugalLapwing,OddPlover
+
+## 01 · whoami — every session has a handle
+
+> a fresh session lands in the repo.
+> first question: what am I called here?
+
+@FrugalLapwing $ loto whoami
+  handle: FrugalLapwing
+  uuid:   818772ce
+
+> that handle is what peers will see.
+
+## 02 · lock + status
+
+@OddPlover $ loto lock a.go --intent "rename Type"
+  ✓ locked count=1
+  (exit 0)
+
+@OddPlover $ loto fail
+  boom
+  (exit 2)
+`
+	s, err := Parse(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if s.Title != "loto demo" {
+		t.Errorf("Title = %q", s.Title)
+	}
+	if len(s.Actors) != 2 || s.Actors[0] != "FrugalLapwing" || s.Actors[1] != "OddPlover" {
+		t.Errorf("Actors = %v", s.Actors)
+	}
+	if len(s.Acts) != 2 {
+		t.Fatalf("Acts = %d", len(s.Acts))
+	}
+	a0 := s.Acts[0]
+	if a0.Number != "01" || !strings.HasPrefix(a0.Title, "whoami") {
+		t.Errorf("act0 hdr = %+v", a0)
+	}
+	if len(a0.Beats) != 4 {
+		t.Fatalf("act0 beats = %d", len(a0.Beats))
+	}
+	if a0.Beats[0].Kind != BeatNarration || a0.Beats[0].Narration != "a fresh session lands in the repo." {
+		t.Errorf("act0 beat0 = %+v", a0.Beats[0])
+	}
+	if a0.Beats[2].Kind != BeatCommand {
+		t.Fatalf("act0 beat2 kind = %v", a0.Beats[2].Kind)
+	}
+	cmd := a0.Beats[2].Command
+	if cmd.Actor != "FrugalLapwing" || cmd.Cmd != "loto whoami" {
+		t.Errorf("cmd = %+v", cmd)
+	}
+	if len(cmd.Output) != 2 || cmd.Output[0] != "handle: FrugalLapwing" {
+		t.Errorf("cmd.Output = %v", cmd.Output)
+	}
+	if cmd.Exit != 0 {
+		t.Errorf("cmd.Exit = %d, want 0 (no trailer)", cmd.Exit)
+	}
+
+	a1 := s.Acts[1]
+	if len(a1.Beats) != 2 {
+		t.Fatalf("act1 beats = %d", len(a1.Beats))
+	}
+	c0 := a1.Beats[0].Command
+	if c0.Cmd != `loto lock a.go --intent "rename Type"` {
+		t.Errorf("c0.Cmd = %q", c0.Cmd)
+	}
+	if c0.Exit != 0 || len(c0.Output) != 1 {
+		t.Errorf("c0 = %+v", c0)
+	}
+	c1 := a1.Beats[1].Command
+	if c1.Exit != 2 || len(c1.Output) != 1 || c1.Output[0] != "boom" {
+		t.Errorf("c1 = %+v", c1)
+	}
+}
+
+func TestParse_emptyScene(t *testing.T) {
+	s, err := Parse(strings.NewReader("# fo:scene\n"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(s.Acts) != 0 || s.Title != "" || len(s.Actors) != 0 {
+		t.Errorf("empty scene non-zero: %+v", s)
+	}
+}
+
+func TestParse_commentsAfterHeader(t *testing.T) {
+	in := "# fo:scene\n# a comment\n## 01 · t\n# another\n> hi\n"
+	s, err := Parse(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(s.Acts) != 1 || len(s.Acts[0].Beats) != 1 {
+		t.Fatalf("got %+v", s)
+	}
+}
+
+func TestParse_errors(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want error
+	}{
+		{"no header", "## 01 · t\n", ErrNoHeader},
+		{"empty input", "", ErrNoHeader},
+		{"malformed act no dot", "# fo:scene\n## 01 nothing\n", ErrMalformedAct},
+		{"malformed act empty title", "# fo:scene\n## 01 · \n", ErrMalformedAct},
+		{"malformed actor no dollar", "# fo:scene\n## 01 · t\n@actor cmd\n", ErrMalformedActor},
+		{"malformed actor empty cmd", "# fo:scene\n## 01 · t\n@actor $ \n", ErrMalformedActor},
+		{"bad exit code", "# fo:scene\n## 01 · t\n@a $ c\n  out\n  (exit oops)\n", ErrMalformedExit},
+		{"unknown attr", "# fo:scene foo=bar\n", ErrUnknownAttr},
+		{"narration before act", "# fo:scene\n> nope\n", ErrMalformedAct},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := Parse(strings.NewReader(c.in))
+			if !errors.Is(err, c.want) {
+				t.Errorf("err = %v, want Is %v", err, c.want)
+			}
+		})
+	}
+}
+
+func TestParse_headerAttrs(t *testing.T) {
+	in := `# fo:scene title="hello world" actors=A,B,C
+## 01 · t
+> x
+`
+	s, err := Parse(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if s.Title != "hello world" {
+		t.Errorf("Title = %q", s.Title)
+	}
+	if len(s.Actors) != 3 || s.Actors[2] != "C" {
+		t.Errorf("Actors = %v", s.Actors)
+	}
+}
+
+func TestParse_outputTerminatesOnNonIndented(t *testing.T) {
+	in := `# fo:scene
+## 01 · t
+@a $ cmd
+  out1
+  out2
+> narration after
+`
+	s, err := Parse(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	beats := s.Acts[0].Beats
+	if len(beats) != 2 {
+		t.Fatalf("beats = %d", len(beats))
+	}
+	if beats[0].Kind != BeatCommand || len(beats[0].Command.Output) != 2 {
+		t.Errorf("cmd beat = %+v", beats[0])
+	}
+	if beats[1].Kind != BeatNarration || beats[1].Narration != "narration after" {
+		t.Errorf("narr beat = %+v", beats[1])
+	}
+}


### PR DESCRIPTION
## Summary

Implements bead **fo-fl0.1** — `pkg/scene/` parser for the new `# fo:scene` narrated multi-actor walk-through format.

- `Scene`, `Act`, `Beat` (narration | command), `Command` types
- `IsHeader(data []byte) bool`, `Parse(io.Reader) (Scene, error)`
- Sentinel errors: `ErrNoHeader`, `ErrMalformedAct`, `ErrMalformedActor`, `ErrMalformedExit`, `ErrUnknownAttr` — all wrapped with line numbers
- Mirrors `pkg/status` and `pkg/suppress` shape: package doc, scanner-based Parse, tokenizer state struct, errors.Is-friendly sentinels
- 8 test functions covering happy path, IsHeader, header attrs, empty scene, comments, output termination, and all error categories

## Grammar tweak

The bead spec said "`(exit N)` line, if present immediately after output, sets Command.Exit". An `(exit N)`-shaped indented line is treated as the exit trailer and ends the command. Other indented parenthesized content (e.g. `  (warning)`) stays in Output verbatim. Documented in the package doc.

## Out of scope (separate beads)

- fo-fl0.2 / fo-fl0.3: human + LLM renderers in `pkg/view/`
- fo-fl0.4: `cmd/fo/` detection + dispatch
- fo-fl0.5: exhaustive grammar + round-trip tests

## Test plan

- [x] `go test ./pkg/scene/...` — all pass
- [x] `go vet ./pkg/scene/...` — clean
- [x] `golangci-lint run ./pkg/scene/...` — 0 issues