### PR TITLE
chore: go mod tidy — fsnotify, termenv direct (fo-m97)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ toolchain go1.24.7
 
 require (
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/fsnotify/fsnotify v1.10.1
+	github.com/muesli/termenv v0.16.0
 	golang.org/x/term v0.37.0
 )
 
@@ -16,11 +18,9 @@ require (
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
-	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sys v0.38.0 // indirect


### PR DESCRIPTION
Trivial cleanup — `go mod tidy` moves `github.com/fsnotify/fsnotify` and `github.com/muesli/termenv` out of the `// indirect` block. Both are used directly in fo (gopls/golangci-lint flag the staleness).

Closes fo-m97.

## Test plan
- [x] `go mod tidy` produces only the move (no other deps shuffled)
- [x] `go build ./...` still passes
- [x] `go test ./...` still passes