### PR TITLE
scene: strict tab rejection + zero-alloc IsHeader (fo-fcb, fo-a21)

### DIFF
--- a/pkg/scene/scene.go
+++ b/pkg/scene/scene.go
@@ -32,6 +32,7 @@ package scene
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -81,25 +82,26 @@ type Scene struct {
 // IsHeader reports whether data starts (modulo leading whitespace and
 // blank lines) with the scene header prefix.
 func IsHeader(data []byte) bool {
-	s := string(data)
+	headerPrefix := []byte(HeaderPrefix)
+	s := data
 	for {
-		nl := strings.IndexByte(s, '\n')
-		var line string
+		nl := bytes.IndexByte(s, '\n')
+		var line []byte
 		if nl < 0 {
 			line = s
-			s = ""
+			s = nil
 		} else {
 			line = s[:nl]
 			s = s[nl+1:]
 		}
-		trimmed := strings.TrimLeft(line, " \t\r")
-		if trimmed == "" {
+		trimmed := bytes.TrimLeft(line, " \t\r")
+		if len(trimmed) == 0 {
 			if nl < 0 {
 				return false
 			}
 			continue
 		}
-		return strings.HasPrefix(trimmed, HeaderPrefix)
+		return bytes.HasPrefix(trimmed, headerPrefix)
 	}
 }
 
@@ -244,7 +246,7 @@ func isOutputLine(raw string) bool {
 		return false
 	}
 	// reject 3+ leading spaces or tab indent (terminates command).
-	if len(raw) >= 3 && raw[2] == ' ' {
+	if len(raw) >= 3 && (raw[2] == ' ' || raw[2] == '\t') {
 		return false
 	}
 	return true

--- a/pkg/scene/scene_test.go
+++ b/pkg/scene/scene_test.go
@@ -167,6 +167,26 @@ func TestParse_headerAttrs(t *testing.T) {
 	}
 }
 
+func TestParse_outputTerminatesOnTabIndent(t *testing.T) {
+	// "  \tafter" is not a valid 2-space output line; it terminates the
+	// command and is reparsed as narration.
+	in := "# fo:scene\n## 01 · t\n@a $ cmd\n  out1\n  \t> after\n"
+	s, err := Parse(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	beats := s.Acts[0].Beats
+	if len(beats) != 2 {
+		t.Fatalf("beats = %+v", beats)
+	}
+	if got := beats[0].Command.Output; len(got) != 1 || got[0] != "out1" {
+		t.Errorf("Output = %v, want [out1]", got)
+	}
+	if beats[1].Kind != BeatNarration || beats[1].Narration != "after" {
+		t.Errorf("narr beat = %+v", beats[1])
+	}
+}
+
 func TestParse_outputTerminatesOnNonIndented(t *testing.T) {
 	in := `# fo:scene
 ## 01 · t


### PR DESCRIPTION
## Summary
- `pkg/scene.isOutputLine` now rejects tab at position 2 (was: rejected only 3+ spaces). Matches the 2-space-exact rule the docstring already promised.
- `pkg/scene.IsHeader` walks `[]byte` directly via `bytes.IndexByte/TrimLeft/HasPrefix`, dropping the `string(data)` copy of the full input.
- New `TestParse_outputTerminatesOnTabIndent` covers the tab case.

Closes Gemini follow-ups on #273 (beads fo-fcb, fo-a21).

## Test plan
- [x] `go test ./pkg/scene/...`
- [x] `go vet ./...`
- [x] `go build ./...`