### PR TITLE
view: LLM scene renderer (fo-fl0.3)

### DIFF
--- a/pkg/view/scene_llm.go
+++ b/pkg/view/scene_llm.go
@@ -1,0 +1,111 @@
+package view
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/dkoosis/fo/pkg/scene"
+)
+
+// RenderSceneLLM emits a scene in the canonical `# fo:scene` text form.
+// Output is plain text with no ANSI; structure is preserved so the result
+// round-trips through scene.Parse.
+func RenderSceneLLM(w io.Writer, s scene.Scene) error {
+	if err := writeSceneHeader(w, s); err != nil {
+		return err
+	}
+	for i, act := range s.Acts {
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "## %s · %s\n", act.Number, act.Title); err != nil {
+			return err
+		}
+		if err := writeBeats(w, act.Beats); err != nil {
+			return err
+		}
+		_ = i
+	}
+	return nil
+}
+
+func writeSceneHeader(w io.Writer, s scene.Scene) error {
+	var b strings.Builder
+	b.WriteString(scene.HeaderPrefix)
+	if s.Title != "" {
+		// title may contain spaces; quote it. Embedded quotes are escaped
+		// with backslash to match the parser's quote-aware tokenizer.
+		b.WriteString(` title="`)
+		b.WriteString(escapeQuoted(s.Title))
+		b.WriteByte('"')
+	}
+	if len(s.Actors) > 0 {
+		b.WriteString(" actors=")
+		b.WriteString(strings.Join(s.Actors, ","))
+	}
+	b.WriteByte('\n')
+	_, err := io.WriteString(w, b.String())
+	return err
+}
+
+func writeBeats(w io.Writer, beats []scene.Beat) error {
+	for _, beat := range beats {
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+		switch beat.Kind {
+		case scene.BeatNarration:
+			if err := writeNarration(w, beat.Narration); err != nil {
+				return err
+			}
+		case scene.BeatCommand:
+			if err := writeCommand(w, beat.Command); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func writeNarration(w io.Writer, text string) error {
+	if text == "" {
+		_, err := fmt.Fprintln(w, ">")
+		return err
+	}
+	_, err := fmt.Fprintf(w, "> %s\n", text)
+	return err
+}
+
+func writeCommand(w io.Writer, c scene.Command) error {
+	if _, err := fmt.Fprintf(w, "@%s $ %s\n", c.Actor, c.Cmd); err != nil {
+		return err
+	}
+	for _, line := range c.Output {
+		if _, err := fmt.Fprintf(w, "  %s\n", line); err != nil {
+			return err
+		}
+	}
+	if c.Exit != 0 {
+		if _, err := fmt.Fprintf(w, "  (exit %d)\n", c.Exit); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func escapeQuoted(s string) string {
+	if !strings.ContainsAny(s, `"\`) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '"' || c == '\\' {
+			b.WriteByte('\\')
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
+}

--- a/pkg/view/scene_llm_test.go
+++ b/pkg/view/scene_llm_test.go
@@ -1,0 +1,138 @@
+package view_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/dkoosis/fo/pkg/scene"
+	"github.com/dkoosis/fo/pkg/view"
+)
+
+// canonicalSceneInput is the loto-demo from pkg/scene/scene_test.go::TestParse_happy.
+const canonicalSceneInput = `# fo:scene title="loto demo" actors=FrugalLapwing,OddPlover
+
+## 01 · whoami — every session has a handle
+
+> a fresh session lands in the repo.
+> first question: what am I called here?
+
+@FrugalLapwing $ loto whoami
+  handle: FrugalLapwing
+  uuid:   818772ce
+
+> that handle is what peers will see.
+
+## 02 · lock + status
+
+@OddPlover $ loto lock a.go --intent "rename Type"
+  ✓ locked count=1
+  (exit 0)
+
+@OddPlover $ loto fail
+  boom
+  (exit 2)
+`
+
+func TestRenderSceneLLM_roundTrip(t *testing.T) {
+	first, err := scene.Parse(strings.NewReader(canonicalSceneInput))
+	if err != nil {
+		t.Fatalf("parse 1: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := view.RenderSceneLLM(&buf, first); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	second, err := scene.Parse(&buf)
+	if err != nil {
+		t.Fatalf("parse 2: %v\n--- rendered ---\n%s", err, buf.String())
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Errorf("round-trip not stable\nfirst:  %+v\nsecond: %+v", first, second)
+	}
+}
+
+func TestRenderSceneLLM_noANSI(t *testing.T) {
+	s, err := scene.Parse(strings.NewReader(canonicalSceneInput))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := view.RenderSceneLLM(&buf, s); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	ansi := regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
+	if ansi.MatchString(buf.String()) {
+		t.Errorf("output contains ANSI escapes:\n%q", buf.String())
+	}
+}
+
+func TestRenderSceneLLM_golden(t *testing.T) {
+	s, err := scene.Parse(strings.NewReader(canonicalSceneInput))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := view.RenderSceneLLM(&buf, s); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	goldenPath := filepath.Join("testdata", "golden", "scene_loto_demo.golden")
+	if *update {
+		if err := os.WriteFile(goldenPath, buf.Bytes(), 0o644); err != nil {
+			t.Fatalf("write golden: %v", err)
+		}
+		return
+	}
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden (%s): %v", goldenPath, err)
+	}
+	if !bytes.Equal(buf.Bytes(), want) {
+		t.Errorf("golden mismatch\n--- got ---\n%s\n--- want ---\n%s", buf.String(), string(want))
+	}
+}
+
+func TestRenderSceneLLM_emptyHeader(t *testing.T) {
+	var buf bytes.Buffer
+	if err := view.RenderSceneLLM(&buf, scene.Scene{}); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if got := buf.String(); got != "# fo:scene\n" {
+		t.Errorf("empty scene = %q", got)
+	}
+	// And it must round-trip.
+	s2, err := scene.Parse(&buf)
+	if err != nil {
+		t.Fatalf("reparse: %v", err)
+	}
+	if s2.Title != "" || len(s2.Actors) != 0 || len(s2.Acts) != 0 {
+		t.Errorf("reparsed empty = %+v", s2)
+	}
+}
+
+func TestRenderSceneLLM_emptyNarration(t *testing.T) {
+	s := scene.Scene{
+		Acts: []scene.Act{{
+			Number: "01", Title: "t",
+			Beats: []scene.Beat{{Kind: scene.BeatNarration, Narration: ""}},
+		}},
+	}
+	var buf bytes.Buffer
+	if err := view.RenderSceneLLM(&buf, s); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if !strings.Contains(buf.String(), "\n>\n") {
+		t.Errorf("empty narration missing bare '>':\n%s", buf.String())
+	}
+	s2, err := scene.Parse(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("reparse: %v", err)
+	}
+	if !reflect.DeepEqual(s, s2) {
+		t.Errorf("round-trip mismatch:\n%+v\nvs\n%+v", s, s2)
+	}
+}

--- a/pkg/view/testdata/golden/scene_loto_demo.golden
+++ b/pkg/view/testdata/golden/scene_loto_demo.golden
@@ -1,0 +1,22 @@
+# fo:scene title="loto demo" actors=FrugalLapwing,OddPlover
+
+## 01 · whoami — every session has a handle
+
+> a fresh session lands in the repo.
+
+> first question: what am I called here?
+
+@FrugalLapwing $ loto whoami
+  handle: FrugalLapwing
+  uuid:   818772ce
+
+> that handle is what peers will see.
+
+## 02 · lock + status
+
+@OddPlover $ loto lock a.go --intent "rename Type"
+  ✓ locked count=1
+
+@OddPlover $ loto fail
+  boom
+  (exit 2)


### PR DESCRIPTION
## Summary
- Adds `view.RenderSceneLLM(w, scene.Scene)` — plain-text emitter for `# fo:scene` documents.
- Output round-trips through `scene.Parse`: parse → render → parse yields a semantically equal `Scene`.
- No ANSI; mirrors the input format documented at the top of `pkg/scene/scene.go`.

Closes fo-fl0.3.

## Test plan
- [x] `go test ./...` — all packages pass
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] Round-trip test on canonical loto-demo input (`TestRenderSceneLLM_roundTrip`)
- [x] No-ANSI check (`TestRenderSceneLLM_noANSI`)
- [x] Golden fixture at `pkg/view/testdata/golden/scene_loto_demo.golden`
- [x] Edge cases: empty scene header, empty narration (bare `>`)