### PR TITLE
view: human scene renderer (fo-fl0.2)

### DIFF
--- a/pkg/view/scene_human.go
+++ b/pkg/view/scene_human.go
@@ -1,0 +1,118 @@
+package view
+
+import (
+	"fmt"
+	"hash/fnv"
+	"io"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/dkoosis/fo/pkg/scene"
+	"github.com/dkoosis/fo/pkg/theme"
+)
+
+// sceneRuleWidth is the default horizontal rule width used for act
+// headers when no terminal width is known. Matches the conventional
+// 60-char column for Tufte-Swiss text layouts.
+const sceneRuleWidth = 60
+
+// actorPalette is a small fixed palette of lipgloss colors. Actor
+// names hash into this slice for stable per-scene colorization.
+// 256-color ANSI; chosen to be distinguishable on dark and light TTYs
+// without clashing with theme severity/outcome colors (red/green).
+var actorPalette = []lipgloss.Color{
+	lipgloss.Color("39"),  // blue
+	lipgloss.Color("141"), // violet
+	lipgloss.Color("178"), // gold
+	lipgloss.Color("44"),  // teal
+	lipgloss.Color("204"), // pink
+	lipgloss.Color("108"), // sage
+}
+
+// RenderSceneHuman renders a parsed Scene for a TTY: horizontal-rule
+// act headers, dimmed narration, accent-colored actor prompts, and
+// monospace command output. Exit zero is suppressed; non-zero is
+// rendered in the error color.
+func RenderSceneHuman(w io.Writer, s scene.Scene) error {
+	t := theme.Color()
+	return renderScene(w, s, t)
+}
+
+func renderScene(w io.Writer, s scene.Scene, t theme.Theme) error {
+	if s.Title != "" {
+		if _, err := fmt.Fprintf(w, "%s\n\n", t.Heading.Render(s.Title)); err != nil {
+			return err
+		}
+	}
+	rule := strings.Repeat("─", sceneRuleWidth)
+	for i, act := range s.Acts {
+		if i > 0 {
+			if _, err := fmt.Fprintln(w); err != nil {
+				return err
+			}
+		}
+		if err := renderAct(w, act, t, rule); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func renderAct(w io.Writer, act scene.Act, t theme.Theme, rule string) error {
+	if _, err := fmt.Fprintf(w, "%s\n%s\n\n", t.Muted.Render(rule),
+		t.Heading.Render(act.Number+" · "+act.Title)); err != nil {
+		return err
+	}
+	for _, beat := range act.Beats {
+		switch beat.Kind {
+		case scene.BeatNarration:
+			if err := renderNarration(w, beat.Narration, t); err != nil {
+				return err
+			}
+		case scene.BeatCommand:
+			if err := renderCommand(w, beat.Command, t); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func renderNarration(w io.Writer, text string, t theme.Theme) error {
+	_, err := fmt.Fprintf(w, "  %s\n", t.Muted.Render(text))
+	return err
+}
+
+func renderCommand(w io.Writer, cmd scene.Command, t theme.Theme) error {
+	actor := actorStyle(cmd.Actor).Render(cmd.Actor)
+	prompt := t.Bold.Render("❯")
+	if _, err := fmt.Fprintf(w, "%s %s %s\n", actor, prompt, cmd.Cmd); err != nil {
+		return err
+	}
+	for _, line := range cmd.Output {
+		if _, err := fmt.Fprintf(w, "  %s\n", line); err != nil {
+			return err
+		}
+	}
+	if cmd.Exit != 0 {
+		exit := t.Fail.Render(fmt.Sprintf("(exit %d)", cmd.Exit))
+		if _, err := fmt.Fprintf(w, "  %s\n", exit); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// actorStyle returns a stable foreground style for the actor by
+// hashing the name into actorPalette. Empty actor falls back to the
+// first palette slot.
+func actorStyle(actor string) lipgloss.Style {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(actor))
+	idx := int(h.Sum32()) % len(actorPalette)
+	if idx < 0 {
+		idx = -idx
+	}
+	return lipgloss.NewStyle().Foreground(actorPalette[idx]).Bold(true)
+}

--- a/pkg/view/scene_human_test.go
+++ b/pkg/view/scene_human_test.go
@@ -1,0 +1,72 @@
+package view_test
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/dkoosis/fo/pkg/scene"
+	"github.com/dkoosis/fo/pkg/view"
+)
+
+var ansiRE = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripANSI(s string) string { return ansiRE.ReplaceAllString(s, "") }
+
+func TestRenderSceneHuman(t *testing.T) {
+	s := scene.Scene{
+		Title:  "Demo",
+		Actors: []string{"FrugalLapwing", "BraveOtter"},
+		Acts: []scene.Act{
+			{
+				Number: "1",
+				Title:  "Setup",
+				Beats: []scene.Beat{
+					{Kind: scene.BeatNarration, Narration: "Two agents claim territory."},
+					{Kind: scene.BeatCommand, Command: scene.Command{
+						Actor: "FrugalLapwing", Cmd: "loto whoami",
+						Output: []string{"FrugalLapwing"},
+					}},
+				},
+			},
+			{
+				Number: "2",
+				Title:  "Conflict",
+				Beats: []scene.Beat{
+					{Kind: scene.BeatCommand, Command: scene.Command{
+						Actor: "BraveOtter", Cmd: "loto acquire pkg/x",
+						Output: []string{"held by FrugalLapwing"},
+						Exit:   1,
+					}},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := view.RenderSceneHuman(&buf, s); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	plain := stripANSI(buf.String())
+
+	for _, want := range []string{
+		"Demo",
+		"1 · Setup",
+		"2 · Conflict",
+		"Two agents claim territory.",
+		"FrugalLapwing",
+		"BraveOtter",
+		"❯ loto whoami",
+		"❯ loto acquire pkg/x",
+		"  held by FrugalLapwing",
+		"(exit 1)",
+	} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("missing %q in:\n%s", want, plain)
+		}
+	}
+	if strings.Contains(plain, "(exit 0)") {
+		t.Errorf("zero exit should be suppressed, got:\n%s", plain)
+	}
+}


### PR DESCRIPTION
## Summary

- Implements `RenderSceneHuman(w, scene.Scene) error` in `pkg/view/scene_human.go`.
- Tufte-Swiss feel matching `# fo:status` aesthetic: horizontal-rule act headers, dimmed narration, accent-colored actor prompts (`❯`), 2-space output gutter, red `(exit N)` for non-zero exits (zero is suppressed).
- Actor → color mapping is stable per scene via FNV hash into a 6-color lipgloss palette chosen to not clash with severity/outcome colors.

Closes fo-fl0.2.

## Test plan

- [x] `go test ./...` — all pass (new `TestRenderSceneHuman` covers 2 actors, 2 acts, one non-zero exit; strips ANSI for assertions)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean