### PR TITLE
report: wire failure clusterer into Report (fo-u15.3.2)

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -55,6 +55,21 @@ type TestResult struct {
 	FixCommand  string        `json:"fix_command,omitempty"`
 	Fingerprint string        `json:"fingerprint,omitempty"`
 	Score       float64       `json:"score,omitempty"`
+	ClusterID   string        `json:"cluster_id,omitempty"`
+}
+
+// Cluster groups failing tests that share a root cause — same topmost
+// user-code stack frame or normalized assertion text. The clusterer
+// (pkg/cluster) produces these; renderers collapse N members behind one
+// expandable group. Singletons (one member) carry no ClusterID on their
+// TestResult and do not appear in Report.Clusters.
+type Cluster struct {
+	ID            string   `json:"id"`
+	Signature     string   `json:"signature"`
+	SignatureKind string   `json:"signature_kind"`
+	TopUserFrame  string   `json:"top_user_frame,omitempty"`
+	NormSig       string   `json:"norm_sig,omitempty"`
+	Members       []string `json:"members"`
 }
 
 // Report is the canonical shape from parser to pickView to renderer.
@@ -70,6 +85,7 @@ type Report struct {
 	DataHash    string       `json:"data_hash,omitempty"`
 	Findings    []Finding    `json:"findings,omitempty"`
 	Tests       []TestResult `json:"tests,omitempty"`
+	Clusters    []Cluster    `json:"clusters,omitempty"`
 	Diff        *DiffSummary `json:"diff,omitempty"`
 	// Notices carries operational warnings about the run itself (e.g.
 	// sidecar state Save failure → diff classification will be stale on

--- a/pkg/report/report.schema.json
+++ b/pkg/report/report.schema.json
@@ -29,6 +29,11 @@
       "description": "Test or package outcomes from go test -json. Empty or omitted when no tests.",
       "items": { "$ref": "#/$defs/TestResult" }
     },
+    "clusters": {
+      "type": "array",
+      "description": "Failure clusters: groups of >=2 failing tests sharing a root cause (top user frame or normalized assertion). Singletons omitted; their members carry no cluster_id.",
+      "items": { "$ref": "#/$defs/Cluster" }
+    },
     "diff": {
       "oneOf": [
         { "type": "null" },
@@ -79,7 +84,20 @@
         "output":      { "type": "string" },
         "fix_command": { "type": "string" },
         "fingerprint": { "type": "string" },
-        "score":       { "type": "number" }
+        "score":       { "type": "number" },
+        "cluster_id":  { "type": "string", "description": "Failure cluster identifier (F-xxxxxx). Present only when this test belongs to a cluster of 2+ failures sharing a root cause." }
+      }
+    },
+    "Cluster": {
+      "type": "object",
+      "required": ["id", "signature", "signature_kind", "members"],
+      "properties": {
+        "id":              { "type": "string", "description": "Short stable run-local identifier (F-xxxxxx)." },
+        "signature":       { "type": "string", "description": "The signal that anchors the cluster (frame string, normalized assertion, or singleton key)." },
+        "signature_kind":  { "type": "string", "enum": ["frame", "norm", "singleton"], "description": "Which signal produced the signature." },
+        "top_user_frame":  { "type": "string", "description": "Topmost user-code stack frame shared by the cluster, if any." },
+        "norm_sig":        { "type": "string", "description": "Normalized assertion-text anchor shared by the cluster, if any." },
+        "members":         { "type": "array", "items": { "type": "string" }, "description": "Fingerprints of the TestResults in this cluster." }
       }
     },
     "DiffItem": {

--- a/pkg/testjson/cluster_wire_test.go
+++ b/pkg/testjson/cluster_wire_test.go
@@ -1,0 +1,115 @@
+package testjson
+
+import (
+	"testing"
+
+	"github.com/dkoosis/fo/pkg/report"
+)
+
+// TestAttachClusters_SharedFrameGroupsFailures verifies that two failing
+// tests sharing the same user-code frame land in the same cluster and
+// both TestResults receive the matching ClusterID.
+func TestAttachClusters_SharedFrameGroupsFailures(t *testing.T) {
+	t.Parallel()
+	results := []TestPackageResult{{
+		Name:   "example.com/pkg/x",
+		Failed: 2,
+		FailedTests: []FailedTest{
+			{Name: "TestA", Output: []string{"    x_test.go:5: oops"}},
+			{Name: "TestB", Output: []string{"    x_test.go:5: oops"}},
+		},
+	}}
+
+	r := ToReport(results)
+
+	if len(r.Clusters) != 1 {
+		t.Fatalf("len(Clusters) = %d, want 1; got %#v", len(r.Clusters), r.Clusters)
+	}
+	got := r.Clusters[0]
+	if got.ID == "" {
+		t.Fatal("cluster ID empty")
+	}
+	if len(got.Members) != 2 {
+		t.Fatalf("len(Members) = %d, want 2", len(got.Members))
+	}
+
+	var stamped int
+	for _, tr := range r.Tests {
+		if tr.ClusterID == got.ID {
+			stamped++
+		}
+	}
+	if stamped != 2 {
+		t.Fatalf("expected 2 tests stamped with cluster ID %q, got %d", got.ID, stamped)
+	}
+}
+
+// TestAttachClusters_SingletonsHaveNoClusterID verifies that a failure
+// not sharing a signal with any other failure does not get a ClusterID
+// and does not appear in Report.Clusters.
+func TestAttachClusters_SingletonsHaveNoClusterID(t *testing.T) {
+	t.Parallel()
+	results := []TestPackageResult{{
+		Name:   "example.com/pkg/x",
+		Failed: 2,
+		FailedTests: []FailedTest{
+			{Name: "TestA", Output: []string{"    a_test.go:5: alpha distinct"}},
+			{Name: "TestB", Output: []string{"    b_test.go:9: bravo separate"}},
+		},
+	}}
+
+	r := ToReport(results)
+
+	if len(r.Clusters) != 0 {
+		t.Fatalf("len(Clusters) = %d, want 0 (all singletons)", len(r.Clusters))
+	}
+	for _, tr := range r.Tests {
+		if tr.ClusterID != "" {
+			t.Errorf("test %s/%s got ClusterID %q, want empty",
+				tr.Package, tr.Test, tr.ClusterID)
+		}
+	}
+}
+
+// TestAttachClusters_PassingTestsHaveNoClusterID verifies that passing
+// (and skipped) tests are never fed to the clusterer and therefore
+// never carry a ClusterID, even when failing siblings cluster up.
+func TestAttachClusters_PassingTestsHaveNoClusterID(t *testing.T) {
+	t.Parallel()
+	results := []TestPackageResult{
+		{
+			Name:   "example.com/pkg/x",
+			Failed: 2,
+			FailedTests: []FailedTest{
+				{Name: "TestA", Output: []string{"    x_test.go:5: oops"}},
+				{Name: "TestB", Output: []string{"    x_test.go:5: oops"}},
+			},
+		},
+		{
+			Name:   "example.com/pkg/y",
+			Passed: 1,
+		},
+	}
+
+	r := ToReport(results)
+
+	if len(r.Clusters) != 1 {
+		t.Fatalf("len(Clusters) = %d, want 1", len(r.Clusters))
+	}
+	for _, tr := range r.Tests {
+		if tr.Outcome == report.OutcomePass && tr.ClusterID != "" {
+			t.Errorf("passing test %s got ClusterID %q, want empty",
+				tr.Package, tr.ClusterID)
+		}
+	}
+}
+
+// TestAttachClusters_EmptyTestsNoOp verifies attachClusters does not
+// allocate Clusters for a Report with no tests.
+func TestAttachClusters_EmptyTestsNoOp(t *testing.T) {
+	t.Parallel()
+	r := ToReport(nil)
+	if r.Clusters != nil {
+		t.Errorf("Clusters = %#v, want nil", r.Clusters)
+	}
+}

--- a/pkg/testjson/toreport.go
+++ b/pkg/testjson/toreport.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dkoosis/fo/pkg/cluster"
 	"github.com/dkoosis/fo/pkg/fingerprint"
 	"github.com/dkoosis/fo/pkg/report"
 	"github.com/dkoosis/fo/pkg/score"
@@ -85,7 +86,74 @@ func ToReport(results []TestPackageResult) *report.Report {
 		return r.Tests[i].Test < r.Tests[j].Test
 	})
 
+	attachClusters(r)
 	return r
+}
+
+// attachClusters runs the failure clusterer over failing tests in r and
+// stamps Test.ClusterID + Report.Clusters. Singletons (clusters with one
+// member) carry no ClusterID and are omitted from Report.Clusters — only
+// groups with shared root cause survive.
+func attachClusters(r *report.Report) {
+	if len(r.Tests) == 0 {
+		return
+	}
+
+	inputs := make([]cluster.Input, 0, len(r.Tests))
+	for i := range r.Tests {
+		t := &r.Tests[i]
+		if !isFailureOutcome(t.Outcome) {
+			continue
+		}
+		inputs = append(inputs, cluster.Input{
+			Key:     t.Fingerprint,
+			Package: t.Package,
+			Test:    t.Test,
+			Outcome: string(t.Outcome),
+			Output:  t.Output,
+		})
+	}
+	if len(inputs) == 0 {
+		return
+	}
+
+	groups := cluster.Run(inputs)
+	if len(groups) == 0 {
+		return
+	}
+
+	keyToID := make(map[string]string)
+	out := make([]report.Cluster, 0, len(groups))
+	for _, g := range groups {
+		if len(g.Members) < 2 {
+			continue
+		}
+		id := string(g.ID)
+		for _, m := range g.Members {
+			keyToID[m] = id
+		}
+		out = append(out, report.Cluster{
+			ID:            id,
+			Signature:     g.Signature,
+			SignatureKind: g.SignatureKind,
+			TopUserFrame:  g.TopUserFrame,
+			NormSig:       g.NormSig,
+			Members:       append([]string(nil), g.Members...),
+		})
+	}
+
+	for i := range r.Tests {
+		if id, ok := keyToID[r.Tests[i].Fingerprint]; ok {
+			r.Tests[i].ClusterID = id
+		}
+	}
+	if len(out) > 0 {
+		r.Clusters = out
+	}
+}
+
+func isFailureOutcome(o report.TestOutcome) bool {
+	return o == report.OutcomeFail || o == report.OutcomePanic || o == report.OutcomeBuildError
 }
 
 // ToReportWithMeta stamps DataHash from raw input bytes the caller already


### PR DESCRIPTION
## Summary
- Run `pkg/cluster` over failing tests inside `testjson.ToReport`; stamp `TestResult.ClusterID` and populate `Report.Clusters` for multi-member groups.
- Add `report.Cluster` type and bump `report.schema.json` with `Cluster` def, `Report.clusters`, and `TestResult.cluster_id` (all additive, all `omitempty`).
- Singletons stay unmarked — renderers (fo-u15.3.3) treat them as ordinary failures.

## Test plan
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] New tests in `pkg/testjson/cluster_wire_test.go`: shared-frame grouping, singletons unmarked, passing tests unmarked, empty no-op.
- [x] `fo --print-schema` shows the new `Cluster` def, `clusters` property, and `cluster_id` field.

Closes fo-u15.3.2.