### PR TITLE
report: apply .fo/ignore suppress filter (fo-u15.2.2)

### DIFF
--- a/cmd/fo/main.go
+++ b/cmd/fo/main.go
@@ -300,6 +300,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 2
 	}
 
+	applySuppress(r, suppressPath(), stderr)
+
 	saveErr := attachDiff(r, *stateFile, *noState, stderr)
 
 	if err := renderMode(mode, r, stdout, *themeFlag); err != nil {
@@ -921,6 +923,7 @@ func runStreamCtx(ctx context.Context, stdin io.Reader, br *bufio.Reader, stdout
 		// error so a partial Report doesn't poison the next run's diff (#262).
 		var saveErr error
 		if parseErr == nil {
+			applySuppress(r, suppressPath(), stderr)
 			saveErr = attachDiff(r, stateFile, noState, stderr)
 		}
 		resultCh <- streamResult{report: r, parseErr: parseErr, saveErr: saveErr}
@@ -1004,6 +1007,7 @@ func runStreamBatch(stdin io.Reader, br *bufio.Reader, stdout io.Writer, mode, t
 		fmt.Fprintf(stderr, "fo: %v\n", err)
 		return 2
 	}
+	applySuppress(r, suppressPath(), stderr)
 	saveErr := attachDiff(r, stateFile, noState, stderr)
 	if err := renderMode(mode, r, stdout, themeName); err != nil {
 		fmt.Fprintf(stderr, "fo: %v\n", err)

--- a/cmd/fo/suppress.go
+++ b/cmd/fo/suppress.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/dkoosis/fo/pkg/report"
+	"github.com/dkoosis/fo/pkg/suppress"
+)
+
+// suppressPath returns the path to .fo/ignore for the current run. The
+// FO_IGNORE env var overrides the default (cwd/.fo/ignore) for tests
+// and non-standard layouts.
+func suppressPath() string {
+	if p := os.Getenv("FO_IGNORE"); p != "" {
+		return p
+	}
+	return filepath.Join(".fo", "ignore")
+}
+
+// applySuppress loads .fo/ignore (if present) and runs report.ApplyFilter
+// on r. Absent file is a no-op. Any other load/parse failure is recorded
+// as a Notice; the run continues.
+func applySuppress(r *report.Report, path string, stderr io.Writer) {
+	if r == nil {
+		return
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return
+		}
+		fmt.Fprintf(stderr, "fo: suppress: %v\n", err)
+		r.Notices = append(r.Notices,
+			fmt.Sprintf("suppress: load failed (%v) — .fo/ignore not applied", err))
+		return
+	}
+	defer f.Close()
+
+	rules, err := suppress.Parse(f)
+	if err != nil {
+		fmt.Fprintf(stderr, "fo: suppress: %v\n", err)
+		r.Notices = append(r.Notices,
+			fmt.Sprintf("suppress: parse failed (%v) — .fo/ignore not applied", err))
+		return
+	}
+	if len(rules) == 0 {
+		return
+	}
+	report.ApplyFilter(r, suppress.NewRuleset(rules), time.Now())
+}

--- a/cmd/fo/suppress_test.go
+++ b/cmd/fo/suppress_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dkoosis/fo/pkg/report"
+)
+
+func TestApplySuppress_AbsentFileNoop(t *testing.T) {
+	r := &report.Report{
+		Findings: []report.Finding{
+			{RuleID: "X", File: "a.go", Severity: report.SeverityWarning},
+		},
+	}
+	var stderr bytes.Buffer
+	applySuppress(r, filepath.Join(t.TempDir(), "does-not-exist"), &stderr)
+	if len(r.Findings) != 1 {
+		t.Errorf("absent file should be no-op, got %d findings", len(r.Findings))
+	}
+	if r.Suppressed != 0 {
+		t.Errorf("Suppressed = %d, want 0", r.Suppressed)
+	}
+	if len(r.Notices) != 0 {
+		t.Errorf("absent file should not add notices: %v", r.Notices)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("unexpected stderr: %q", stderr.String())
+	}
+}
+
+func TestApplySuppress_ParseErrorAddsNotice(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ignore")
+	if err := os.WriteFile(path, []byte("=bogus garbage line\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r := &report.Report{
+		Findings: []report.Finding{{RuleID: "X", File: "a.go"}},
+	}
+	var stderr bytes.Buffer
+	applySuppress(r, path, &stderr)
+	if len(r.Findings) != 1 {
+		t.Errorf("parse failure should not drop findings")
+	}
+	if len(r.Notices) != 1 || !strings.Contains(r.Notices[0], "suppress") {
+		t.Errorf("expected suppress notice, got %v", r.Notices)
+	}
+}
+
+func TestApplySuppress_ActiveRuleSuppresses(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ignore")
+	body := "SA1019 reason=\"upstream\"\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r := &report.Report{
+		Findings: []report.Finding{
+			{RuleID: "SA1019", File: "a.go", Severity: report.SeverityWarning},
+			{RuleID: "OTHER", File: "b.go", Severity: report.SeverityError},
+		},
+	}
+	var stderr bytes.Buffer
+	applySuppress(r, path, &stderr)
+	if len(r.Findings) != 1 || r.Findings[0].RuleID != "OTHER" {
+		t.Errorf("findings after suppress: %+v", r.Findings)
+	}
+	if r.Suppressed != 1 {
+		t.Errorf("Suppressed = %d, want 1", r.Suppressed)
+	}
+}

--- a/pkg/report/filter.go
+++ b/pkg/report/filter.go
@@ -1,0 +1,57 @@
+package report
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dkoosis/fo/pkg/suppress"
+)
+
+// FilterStats records the outcome of ApplyFilter for callers that want
+// per-rule visibility. Total is also reflected on Report.Suppressed.
+type FilterStats struct {
+	Total   int
+	PerRule map[int]int
+}
+
+// ApplyFilter removes Findings matched by active (non-expired) rules in
+// rs and increments Report.Suppressed. Expired rules that still match
+// leave the finding in place and append a Notice warning that the
+// suppression is past its until-date (one Notice per expired rule with
+// at least one match). A nil/empty ruleset is a no-op.
+func ApplyFilter(r *Report, rs *suppress.Ruleset, now time.Time) FilterStats {
+	stats := FilterStats{PerRule: map[int]int{}}
+	if r == nil || rs == nil || len(rs.Rules) == 0 || len(r.Findings) == 0 {
+		return stats
+	}
+
+	expiredNotified := map[int]bool{}
+	kept := r.Findings[:0]
+	for _, f := range r.Findings {
+		idx := rs.Match(f.RuleID, f.File)
+		if idx < 0 {
+			kept = append(kept, f)
+			continue
+		}
+		rule := rs.Rules[idx]
+		if rule.Expired(now) {
+			kept = append(kept, f)
+			if !expiredNotified[idx] {
+				expiredNotified[idx] = true
+				until := ""
+				if rule.Until != nil {
+					until = rule.Until.Format("2006-01-02")
+				}
+				r.Notices = append(r.Notices, fmt.Sprintf(
+					"suppression for %s (line %d) expired %s; finding shown",
+					rule.RuleID, rule.Line, until))
+			}
+			continue
+		}
+		stats.Total++
+		stats.PerRule[idx]++
+	}
+	r.Findings = kept
+	r.Suppressed += stats.Total
+	return stats
+}

--- a/pkg/report/filter_test.go
+++ b/pkg/report/filter_test.go
@@ -1,0 +1,123 @@
+package report
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dkoosis/fo/pkg/suppress"
+)
+
+func mustDate(s string) *time.Time {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+	return &t
+}
+
+func TestApplyFilter_ActiveRuleSuppresses(t *testing.T) {
+	r := &Report{
+		Findings: []Finding{
+			{RuleID: "SA1019", File: "pkg/a.go", Severity: SeverityWarning, Message: "deprecated"},
+			{RuleID: "G115", File: "internal/legacy/x.go", Severity: SeverityWarning, Message: "overflow"},
+			{RuleID: "KEEP", File: "pkg/b.go", Severity: SeverityError, Message: "keep me"},
+		},
+	}
+	rs := suppress.NewRuleset([]suppress.Suppression{
+		{RuleID: "SA1019", Glob: "**", Line: 1},
+		{RuleID: "G115", Glob: "internal/legacy/**", Line: 2},
+	})
+	now := time.Date(2026, 5, 16, 0, 0, 0, 0, time.UTC)
+	stats := ApplyFilter(r, rs, now)
+
+	if len(r.Findings) != 1 || r.Findings[0].RuleID != "KEEP" {
+		t.Errorf("findings after filter: %+v", r.Findings)
+	}
+	if r.Suppressed != 2 {
+		t.Errorf("Suppressed = %d, want 2", r.Suppressed)
+	}
+	if stats.Total != 2 {
+		t.Errorf("stats.Total = %d, want 2", stats.Total)
+	}
+	if stats.PerRule[0] != 1 || stats.PerRule[1] != 1 {
+		t.Errorf("per-rule: %+v", stats.PerRule)
+	}
+	if len(r.Notices) != 0 {
+		t.Errorf("unexpected notices: %v", r.Notices)
+	}
+}
+
+func TestApplyFilter_ExpiredRuleKeepsAndNotices(t *testing.T) {
+	r := &Report{
+		Findings: []Finding{
+			{RuleID: "SA1019", File: "a.go", Severity: SeverityWarning},
+			{RuleID: "SA1019", File: "b.go", Severity: SeverityWarning},
+		},
+	}
+	rs := suppress.NewRuleset([]suppress.Suppression{
+		{RuleID: "SA1019", Glob: "**", Until: mustDate("2025-01-01"), Line: 7},
+	})
+	now := time.Date(2026, 5, 16, 0, 0, 0, 0, time.UTC)
+	stats := ApplyFilter(r, rs, now)
+
+	if len(r.Findings) != 2 {
+		t.Errorf("expired rule should keep findings: %+v", r.Findings)
+	}
+	if r.Suppressed != 0 {
+		t.Errorf("Suppressed = %d, want 0", r.Suppressed)
+	}
+	if stats.Total != 0 {
+		t.Errorf("stats.Total = %d, want 0", stats.Total)
+	}
+	if len(r.Notices) != 1 {
+		t.Fatalf("want 1 notice, got %d: %v", len(r.Notices), r.Notices)
+	}
+	if !strings.Contains(r.Notices[0], "SA1019") || !strings.Contains(r.Notices[0], "expired") {
+		t.Errorf("notice missing SA1019/expired: %q", r.Notices[0])
+	}
+	if !strings.Contains(r.Notices[0], "2025-01-01") {
+		t.Errorf("notice missing date: %q", r.Notices[0])
+	}
+}
+
+func TestApplyFilter_NoRulesetIsNoop(t *testing.T) {
+	r := &Report{
+		Findings: []Finding{{RuleID: "X", File: "a.go", Severity: SeverityWarning}},
+	}
+	stats := ApplyFilter(r, nil, time.Now())
+	if len(r.Findings) != 1 {
+		t.Errorf("nil ruleset must not drop findings")
+	}
+	if r.Suppressed != 0 || stats.Total != 0 {
+		t.Errorf("nil ruleset must not increment counts")
+	}
+
+	empty := suppress.NewRuleset(nil)
+	stats = ApplyFilter(r, empty, time.Now())
+	if len(r.Findings) != 1 || r.Suppressed != 0 || stats.Total != 0 {
+		t.Errorf("empty ruleset must be no-op")
+	}
+}
+
+func TestApplyFilter_HitCounterAccumulates(t *testing.T) {
+	r := &Report{
+		Findings: []Finding{
+			{RuleID: "R", File: "x.go"},
+			{RuleID: "R", File: "y.go"},
+			{RuleID: "R", File: "z.go"},
+		},
+		Suppressed: 5, // simulate prior accumulation
+	}
+	rs := suppress.NewRuleset([]suppress.Suppression{{RuleID: "R", Glob: "**"}})
+	stats := ApplyFilter(r, rs, time.Now())
+	if stats.Total != 3 {
+		t.Errorf("stats.Total = %d, want 3", stats.Total)
+	}
+	if r.Suppressed != 8 {
+		t.Errorf("Suppressed = %d, want 8 (5+3)", r.Suppressed)
+	}
+	if stats.PerRule[0] != 3 {
+		t.Errorf("per-rule[0] = %d, want 3", stats.PerRule[0])
+	}
+}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -75,6 +75,10 @@ type Report struct {
 	// sidecar state Save failure → diff classification will be stale on
 	// the next run). Empty in the happy path; never used for findings.
 	Notices []string `json:"notices,omitempty"`
+	// Suppressed counts findings removed by .fo/ignore active rules
+	// during this run. Zero when no suppressions matched or no .fo/ignore
+	// file was loaded.
+	Suppressed int `json:"suppressed,omitempty"`
 }
 
 // DiffItem mirrors the shape of state.Item without importing pkg/state

--- a/pkg/report/report.schema.json
+++ b/pkg/report/report.schema.json
@@ -40,6 +40,10 @@
       "type": "array",
       "description": "Operational warnings about the run itself (e.g. sidecar save failure). Never used for findings.",
       "items": { "type": "string" }
+    },
+    "suppressed": {
+      "type": "integer",
+      "description": "Count of findings removed by .fo/ignore active rules during this run."
     }
   },
   "$defs": {

--- a/pkg/suppress/match.go
+++ b/pkg/suppress/match.go
@@ -1,0 +1,93 @@
+package suppress
+
+import "strings"
+
+// Ruleset is an ordered list of suppressions loaded from .fo/ignore.
+// The zero value is empty and matches nothing.
+type Ruleset struct {
+	Rules []Suppression
+}
+
+// NewRuleset wraps parsed suppressions into a Ruleset.
+func NewRuleset(rs []Suppression) *Ruleset {
+	return &Ruleset{Rules: rs}
+}
+
+// Match returns the index of the first suppression in rs that matches
+// (ruleID, path), or -1 if none match.
+func (rs *Ruleset) Match(ruleID, path string) int {
+	if rs == nil {
+		return -1
+	}
+	for i := range rs.Rules {
+		if matchSuppression(rs.Rules[i], ruleID, path) {
+			return i
+		}
+	}
+	return -1
+}
+
+func matchSuppression(s Suppression, ruleID, path string) bool {
+	if s.RuleID != ruleID {
+		return false
+	}
+	pat := s.Glob
+	if pat == "" {
+		pat = DefaultGlob
+	}
+	return matchGlob(pat, path)
+}
+
+// matchGlob implements a minimal doublestar-style matcher:
+//   - "**" matches any sequence including path separators (and the empty string).
+//   - "*"  matches any sequence not containing "/".
+//   - "?"  matches any single non-"/" rune.
+//
+// All other runes are literal. The matcher is anchored: the pattern must
+// match the entire path.
+func matchGlob(pattern, name string) bool {
+	return globHere(pattern, name)
+}
+
+func globHere(p, s string) bool {
+	for i := 0; i < len(p); i++ {
+		c := p[i]
+		switch c {
+		case '*':
+			if i+1 < len(p) && p[i+1] == '*' {
+				rest := p[i+2:]
+				rest = strings.TrimPrefix(rest, "/")
+				if rest == "" {
+					return true
+				}
+				for k := 0; k <= len(s); k++ {
+					if globHere(rest, s[k:]) {
+						return true
+					}
+				}
+				return false
+			}
+			rest := p[i+1:]
+			for k := 0; k <= len(s); k++ {
+				if k > 0 && s[k-1] == '/' {
+					break
+				}
+				if globHere(rest, s[k:]) {
+					return true
+				}
+			}
+			return false
+		case '?':
+			if len(s) == 0 || s[0] == '/' {
+				return false
+			}
+			s = s[1:]
+		default:
+			if len(s) == 0 || s[0] != c {
+				return false
+			}
+			s = s[1:]
+		}
+	}
+	return len(s) == 0
+}

--- a/pkg/suppress/match_test.go
+++ b/pkg/suppress/match_test.go
@@ -1,0 +1,56 @@
+package suppress
+
+import "testing"
+
+func TestMatchGlob(t *testing.T) {
+	cases := []struct {
+		pattern, path string
+		want          bool
+	}{
+		{"**", "anything/at/all.go", true},
+		{"**", "", true},
+		{"internal/legacy/**", "internal/legacy/foo.go", true},
+		{"internal/legacy/**", "internal/legacy/sub/bar.go", true},
+		{"internal/legacy/**", "internal/other/foo.go", false},
+		{"cmd/**", "cmd/fo/main.go", true},
+		{"cmd/**", "pkg/cmd/foo.go", false},
+		{"*.go", "main.go", true},
+		{"*.go", "pkg/main.go", false},
+		{"pkg/*/foo.go", "pkg/bar/foo.go", true},
+		{"pkg/*/foo.go", "pkg/bar/baz/foo.go", false},
+		{"exact.go", "exact.go", true},
+		{"exact.go", "exact.gox", false},
+		{"a?c", "abc", true},
+		{"a?c", "a/c", false},
+	}
+	for _, tc := range cases {
+		if got := matchGlob(tc.pattern, tc.path); got != tc.want {
+			t.Errorf("matchGlob(%q, %q) = %v, want %v", tc.pattern, tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestRulesetMatch(t *testing.T) {
+	rs := NewRuleset([]Suppression{
+		{RuleID: "SA1019", Glob: "**"},
+		{RuleID: "G115", Glob: "internal/legacy/**"},
+	})
+
+	if i := rs.Match("SA1019", "anywhere/file.go"); i != 0 {
+		t.Errorf("SA1019 anywhere: got %d, want 0", i)
+	}
+	if i := rs.Match("G115", "internal/legacy/x.go"); i != 1 {
+		t.Errorf("G115 legacy: got %d, want 1", i)
+	}
+	if i := rs.Match("G115", "internal/modern/x.go"); i != -1 {
+		t.Errorf("G115 modern: got %d, want -1", i)
+	}
+	if i := rs.Match("UNKNOWN", "x.go"); i != -1 {
+		t.Errorf("UNKNOWN: got %d, want -1", i)
+	}
+
+	var nilRS *Ruleset
+	if i := nilRS.Match("X", "y"); i != -1 {
+		t.Errorf("nil ruleset: got %d, want -1", i)
+	}
+}


### PR DESCRIPTION
## Summary
- Wires the suppress parser (fo-u15.2.1) into the Report pipeline. `.fo/ignore` (or `FO_IGNORE` override) is loaded after parse and before diff, so suppressed findings don't show up as NEW in diff classification.
- Active rules drop matching findings and increment a new additive `Report.Suppressed` counter. Expired rules leave findings in place and emit a one-shot Notice per rule.
- Adds `suppress.Ruleset` + `Match` with a minimal doublestar matcher (`**`, `*`, `?`). Schema gains `suppressed` (int, omitempty) — backward compatible.
- Wired into all three pipeline entry points: batch parse path, `runStreamCtx`, `runStreamBatch`. Load errors other than ENOENT surface as Notices, never exit-2.

## Test plan
- [x] `go test ./...` — all packages green
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] New tests cover: active rule suppresses, expired rule keeps + adds Notice, hit counter accumulates, absent `.fo/ignore` is no-op, parse error surfaces as Notice.