### PR TITLE
watch: raw-TTY keyboard input r/q (fo-0l9)

### DIFF
--- a/cmd/fo/watch.go
+++ b/cmd/fo/watch.go
@@ -97,6 +97,16 @@ func runWatch(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	// Keyboard control is offered only for the fs trigger source. The stdin
+	// source consumes newlines as triggers and is mutually exclusive with
+	// raw-mode keypress reads on the same descriptor.
+	var keyTriggers <-chan struct{}
+	restoreTTY := func() {}
+	if opts.source != "stdin" {
+		keyTriggers, restoreTTY = keyControl(ctx, stdin, stop)
+	}
+	defer restoreTTY()
+
 	var triggers <-chan struct{}
 	switch opts.source {
 	case "stdin":
@@ -108,6 +118,9 @@ func runWatch(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			return 2
 		}
 		triggers = debounce(ctx, raw, opts.debounce)
+	}
+	if keyTriggers != nil {
+		triggers = fanIn(ctx, triggers, keyTriggers)
 	}
 
 	isTTY := isTTYWriter(stdout)

--- a/cmd/fo/watchkey.go
+++ b/cmd/fo/watchkey.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+
+	"golang.org/x/term"
+)
+
+// keyControl wires raw-TTY keyboard input into the watch loop.
+//
+// When stdin is a TTY, putRawKeys puts it in cbreak/raw mode and spawns a
+// goroutine that reads one byte at a time:
+//   - 'r' or 'R'             → push a manual trigger on the returned channel
+//   - 'q', 'Q', or Ctrl-C    → call cancel to terminate the watch loop
+//
+// In raw mode the kernel no longer translates Ctrl-C to SIGINT, so byte 0x03
+// is treated explicitly. SIGINT/SIGTERM delivered out-of-band (e.g. by a
+// parent process) still works because signal.NotifyContext owns ctx.
+//
+// restore MUST be called on every exit path. It is idempotent.
+//
+// If stdin is not a TTY (piped/redirected) or any setup step fails, this
+// function returns (nil, no-op restore, nil) and the caller falls back to the
+// non-keyboard path.
+func keyControl(ctx context.Context, in io.Reader, cancel context.CancelFunc) (<-chan struct{}, func()) {
+	f, ok := in.(*os.File)
+	if !ok {
+		return nil, func() {}
+	}
+	fd := int(f.Fd())
+	if !term.IsTerminal(fd) {
+		return nil, func() {}
+	}
+	oldState, err := term.MakeRaw(fd)
+	if err != nil {
+		return nil, func() {}
+	}
+
+	var restored bool
+	restore := func() {
+		if restored {
+			return
+		}
+		restored = true
+		_ = term.Restore(fd, oldState)
+	}
+
+	out := make(chan struct{}, 1)
+	// Best-effort: a blocking Read on the raw TTY can't be interrupted by ctx
+	// alone. Closing the descriptor from another goroutine unblocks it.
+	go func() {
+		<-ctx.Done()
+		_ = f.Close()
+	}()
+	go readKeys(f, out, cancel)
+	return out, restore
+}
+
+// readKeys is the goroutine body for keyControl. It exits when the underlying
+// reader returns an error (typically caused by Close on ctx cancel).
+func readKeys(r io.Reader, out chan<- struct{}, cancel context.CancelFunc) {
+	defer close(out)
+	buf := make([]byte, 1)
+	for {
+		n, err := r.Read(buf)
+		if err != nil {
+			return
+		}
+		if n == 0 {
+			continue
+		}
+		switch buf[0] {
+		case 'r', 'R':
+			// Non-blocking send: one rerun in flight is enough; further presses
+			// during a rerun are dropped rather than queued.
+			select {
+			case out <- struct{}{}:
+			default:
+			}
+		case 'q', 'Q', 0x03, 0x04: // Ctrl-C, Ctrl-D
+			cancel()
+			return
+		}
+	}
+}
+
+// fanIn merges two trigger channels into one. The output closes when both
+// inputs are closed or ctx is canceled. A nil channel is treated as a
+// permanently blocked source (Go's standard idiom).
+func fanIn(ctx context.Context, a, b <-chan struct{}) <-chan struct{} {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	out := make(chan struct{})
+	go func() {
+		defer close(out)
+		for a != nil || b != nil {
+			select {
+			case <-ctx.Done():
+				return
+			case _, ok := <-a:
+				if !ok {
+					a = nil
+					continue
+				}
+				select {
+				case out <- struct{}{}:
+				case <-ctx.Done():
+					return
+				}
+			case _, ok := <-b:
+				if !ok {
+					b = nil
+					continue
+				}
+				select {
+				case out <- struct{}{}:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return out
+}

--- a/cmd/fo/watchkey_test.go
+++ b/cmd/fo/watchkey_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestKeyControl_NonTTYReturnsNoop(t *testing.T) {
+	// strings.Reader is not an *os.File → must fall back cleanly.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, restore := keyControl(ctx, strings.NewReader(""), cancel)
+	if ch != nil {
+		t.Fatalf("keyControl: want nil channel on non-TTY, got %v", ch)
+	}
+	if restore == nil {
+		t.Fatal("keyControl: restore must never be nil")
+	}
+	// Restore must be idempotent and safe to call multiple times.
+	restore()
+	restore()
+}
+
+func TestFanIn_BothClose(t *testing.T) {
+	a := make(chan struct{})
+	b := make(chan struct{})
+	close(a)
+	close(b)
+	out := fanIn(context.Background(), a, b)
+	// Drain — should close promptly.
+	select {
+	case _, ok := <-out:
+		if ok {
+			t.Fatal("fanIn: unexpected value from closed inputs")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("fanIn: did not close after both inputs closed")
+	}
+}
+
+func TestFanIn_NilPassthrough(t *testing.T) {
+	a := make(chan struct{}, 1)
+	a <- struct{}{}
+	close(a)
+
+	out := fanIn(context.Background(), a, nil)
+	// fanIn(a, nil) is just a (no goroutine, same channel).
+	got := 0
+	for range out {
+		got++
+	}
+	if got != 1 {
+		t.Fatalf("fanIn nil passthrough: want 1 value, got %d", got)
+	}
+}
+
+func TestFanIn_MergesValues(t *testing.T) {
+	a := make(chan struct{}, 2)
+	b := make(chan struct{}, 2)
+	a <- struct{}{}
+	b <- struct{}{}
+	a <- struct{}{}
+	close(a)
+	close(b)
+
+	out := fanIn(context.Background(), a, b)
+	got := 0
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case _, ok := <-out:
+			if !ok {
+				if got != 3 {
+					t.Fatalf("fanIn: want 3 merged values, got %d", got)
+				}
+				return
+			}
+			got++
+		case <-deadline:
+			t.Fatalf("fanIn: timed out after %d values", got)
+		}
+	}
+}
+
+func TestFanIn_CtxCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	a := make(chan struct{})
+	b := make(chan struct{})
+	out := fanIn(ctx, a, b)
+	cancel()
+	select {
+	case _, ok := <-out:
+		if ok {
+			t.Fatal("fanIn: unexpected value after ctx cancel")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("fanIn: did not close after ctx cancel")
+	}
+}


### PR DESCRIPTION
## Summary

Adds raw-TTY keyboard input to `fo watch`. Split-off from the original A.4 scope; the clear-screen + status-line piece shipped in 44e9e6f.

When stdin is a TTY and `-source=fs`, watch enters raw mode and spawns a reader goroutine:

- `r` / `R` — manual rerun (merged with fs triggers via `fanIn`)
- `q` / `Q` — cancel ctx, exit cleanly
- Ctrl-C / Ctrl-D — cancel ctx, exit cleanly (raw mode disables kernel-level SIGINT translation, so we handle byte `0x03` explicitly)

Terminal mode is restored on every exit path via a deferred idempotent `restore`. Out-of-band `SIGINT`/`SIGTERM` still propagates through `signal.NotifyContext`.

Fallback paths:
- Non-TTY stdin (piped/redirected) → `keyControl` returns `(nil, no-op)`; only ctx cancellation drives shutdown.
- `-source=stdin` → keyboard control disabled (stdin is already the trigger source).
- `term.MakeRaw` failure → no-op, watch proceeds without keys.

## Test plan

- [x] `go test ./...` — full suite passes
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] Unit tests: non-TTY fallback returns nil channel + idempotent restore
- [x] Unit tests: `fanIn` merge / nil-passthrough / ctx-cancel / both-close
- [ ] Manual: `fo watch -- go test ./...` in a real terminal — verify `r` reruns, `q` exits with sane terminal state (`stty -a` shows echo on, shell echoes typed input)
- [ ] Manual: `echo | fo watch -- ...` — confirm no raw-mode entry, Ctrl-C still works via SIGINT

Closes fo-0l9.