### PR TITLE
fix: TTY restore race + cluster Key uniqueness (fo-oq9, fo-juf)

### DIFF
--- a/cmd/fo/watchkey.go
+++ b/cmd/fo/watchkey.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"sync"
 
 	"golang.org/x/term"
 )
@@ -38,20 +39,25 @@ func keyControl(ctx context.Context, in io.Reader, cancel context.CancelFunc) (<
 		return nil, func() {}
 	}
 
-	var restored bool
+	// restore is idempotent and safe to call from multiple goroutines: the
+	// ctx-cancel goroutine restores before closing the fd, and the caller's
+	// defer is a safety net for early-exit paths where the goroutine hasn't
+	// fired yet.
+	var once sync.Once
 	restore := func() {
-		if restored {
-			return
-		}
-		restored = true
-		_ = term.Restore(fd, oldState)
+		once.Do(func() {
+			_ = term.Restore(fd, oldState)
+		})
 	}
 
 	out := make(chan struct{}, 1)
 	// Best-effort: a blocking Read on the raw TTY can't be interrupted by ctx
 	// alone. Closing the descriptor from another goroutine unblocks it.
+	// Restore terminal state before closing — calling term.Restore on a closed
+	// fd would leave the terminal in raw mode.
 	go func() {
 		<-ctx.Done()
+		restore()
 		_ = f.Close()
 	}()
 	go readKeys(f, out, cancel)

--- a/pkg/testjson/cluster_wire_test.go
+++ b/pkg/testjson/cluster_wire_test.go
@@ -104,6 +104,43 @@ func TestAttachClusters_PassingTestsHaveNoClusterID(t *testing.T) {
 	}
 }
 
+// TestAttachClusters_RetriesWithSameFingerprintBothCount verifies that two
+// failing test results with identical fingerprints (e.g. a retried failure
+// with the same name, package, and output) both survive the clusterer
+// rather than collapsing to a singleton and being dropped. Regression for
+// fo-juf: attachClusters previously used Fingerprint as cluster.Input.Key,
+// and the clusterer dedupes by Key (last-write-wins).
+func TestAttachClusters_RetriesWithSameFingerprintBothCount(t *testing.T) {
+	t.Parallel()
+	results := []TestPackageResult{{
+		Name:   "example.com/pkg/x",
+		Failed: 2,
+		FailedTests: []FailedTest{
+			{Name: "TestFlaky", Output: []string{"    x_test.go:5: boom"}},
+			{Name: "TestFlaky", Output: []string{"    x_test.go:5: boom"}},
+		},
+	}}
+
+	r := ToReport(results)
+
+	if len(r.Clusters) != 1 {
+		t.Fatalf("len(Clusters) = %d, want 1; clusters=%#v", len(r.Clusters), r.Clusters)
+	}
+	got := r.Clusters[0]
+	if len(got.Members) != 2 {
+		t.Fatalf("len(Members) = %d, want 2", len(got.Members))
+	}
+	var stamped int
+	for _, tr := range r.Tests {
+		if tr.ClusterID == got.ID {
+			stamped++
+		}
+	}
+	if stamped != 2 {
+		t.Fatalf("expected 2 tests stamped with cluster ID %q, got %d", got.ID, stamped)
+	}
+}
+
 // TestAttachClusters_EmptyTestsNoOp verifies attachClusters does not
 // allocate Clusters for a Report with no tests.
 func TestAttachClusters_EmptyTestsNoOp(t *testing.T) {

--- a/pkg/testjson/cluster_wire_test.go
+++ b/pkg/testjson/cluster_wire_test.go
@@ -6,22 +6,13 @@ import (
 	"github.com/dkoosis/fo/pkg/report"
 )
 
-// TestAttachClusters_SharedFrameGroupsFailures verifies that two failing
-// tests sharing the same user-code frame land in the same cluster and
-// both TestResults receive the matching ClusterID.
-func TestAttachClusters_SharedFrameGroupsFailures(t *testing.T) {
-	t.Parallel()
-	results := []TestPackageResult{{
-		Name:   "example.com/pkg/x",
-		Failed: 2,
-		FailedTests: []FailedTest{
-			{Name: "TestA", Output: []string{"    x_test.go:5: oops"}},
-			{Name: "TestB", Output: []string{"    x_test.go:5: oops"}},
-		},
-	}}
-
+// assertSingleClusterOfTwo runs ToReport and verifies the resulting
+// report contains exactly one cluster with two members, both stamped
+// with its ClusterID. Shared helper for tests that expect two failing
+// tests to cluster together.
+func assertSingleClusterOfTwo(t *testing.T, results []TestPackageResult) {
+	t.Helper()
 	r := ToReport(results)
-
 	if len(r.Clusters) != 1 {
 		t.Fatalf("len(Clusters) = %d, want 1; got %#v", len(r.Clusters), r.Clusters)
 	}
@@ -32,7 +23,6 @@ func TestAttachClusters_SharedFrameGroupsFailures(t *testing.T) {
 	if len(got.Members) != 2 {
 		t.Fatalf("len(Members) = %d, want 2", len(got.Members))
 	}
-
 	var stamped int
 	for _, tr := range r.Tests {
 		if tr.ClusterID == got.ID {
@@ -42,6 +32,21 @@ func TestAttachClusters_SharedFrameGroupsFailures(t *testing.T) {
 	if stamped != 2 {
 		t.Fatalf("expected 2 tests stamped with cluster ID %q, got %d", got.ID, stamped)
 	}
+}
+
+// TestAttachClusters_SharedFrameGroupsFailures verifies that two failing
+// tests sharing the same user-code frame land in the same cluster and
+// both TestResults receive the matching ClusterID.
+func TestAttachClusters_SharedFrameGroupsFailures(t *testing.T) {
+	t.Parallel()
+	assertSingleClusterOfTwo(t, []TestPackageResult{{
+		Name:   "example.com/pkg/x",
+		Failed: 2,
+		FailedTests: []FailedTest{
+			{Name: "TestA", Output: []string{"    x_test.go:5: oops"}},
+			{Name: "TestB", Output: []string{"    x_test.go:5: oops"}},
+		},
+	}})
 }
 
 // TestAttachClusters_SingletonsHaveNoClusterID verifies that a failure
@@ -112,33 +117,14 @@ func TestAttachClusters_PassingTestsHaveNoClusterID(t *testing.T) {
 // and the clusterer dedupes by Key (last-write-wins).
 func TestAttachClusters_RetriesWithSameFingerprintBothCount(t *testing.T) {
 	t.Parallel()
-	results := []TestPackageResult{{
+	assertSingleClusterOfTwo(t, []TestPackageResult{{
 		Name:   "example.com/pkg/x",
 		Failed: 2,
 		FailedTests: []FailedTest{
 			{Name: "TestFlaky", Output: []string{"    x_test.go:5: boom"}},
 			{Name: "TestFlaky", Output: []string{"    x_test.go:5: boom"}},
 		},
-	}}
-
-	r := ToReport(results)
-
-	if len(r.Clusters) != 1 {
-		t.Fatalf("len(Clusters) = %d, want 1; clusters=%#v", len(r.Clusters), r.Clusters)
-	}
-	got := r.Clusters[0]
-	if len(got.Members) != 2 {
-		t.Fatalf("len(Members) = %d, want 2", len(got.Members))
-	}
-	var stamped int
-	for _, tr := range r.Tests {
-		if tr.ClusterID == got.ID {
-			stamped++
-		}
-	}
-	if stamped != 2 {
-		t.Fatalf("expected 2 tests stamped with cluster ID %q, got %d", got.ID, stamped)
-	}
+	}})
 }
 
 // TestAttachClusters_EmptyTestsNoOp verifies attachClusters does not

--- a/pkg/testjson/toreport.go
+++ b/pkg/testjson/toreport.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -99,14 +100,21 @@ func attachClusters(r *report.Report) {
 		return
 	}
 
+	// Key must be unique per test result — cluster.Run dedupes by Key
+	// (last-write-wins), so retries that share a Fingerprint would
+	// collapse to one input and get dropped as a singleton (fo-juf).
+	// Use the r.Tests index as the opaque key.
 	inputs := make([]cluster.Input, 0, len(r.Tests))
+	keyToTestIdx := make(map[string]int, len(r.Tests))
 	for i := range r.Tests {
 		t := &r.Tests[i]
 		if !isFailureOutcome(t.Outcome) {
 			continue
 		}
+		key := strconv.Itoa(i)
+		keyToTestIdx[key] = i
 		inputs = append(inputs, cluster.Input{
-			Key:     t.Fingerprint,
+			Key:     key,
 			Package: t.Package,
 			Test:    t.Test,
 			Outcome: string(t.Outcome),
@@ -122,7 +130,6 @@ func attachClusters(r *report.Report) {
 		return
 	}
 
-	keyToID := make(map[string]string)
 	out := make([]report.Cluster, 0, len(groups))
 	for _, g := range groups {
 		if len(g.Members) < 2 {
@@ -130,7 +137,9 @@ func attachClusters(r *report.Report) {
 		}
 		id := string(g.ID)
 		for _, m := range g.Members {
-			keyToID[m] = id
+			if idx, ok := keyToTestIdx[m]; ok {
+				r.Tests[idx].ClusterID = id
+			}
 		}
 		out = append(out, report.Cluster{
 			ID:            id,
@@ -140,12 +149,6 @@ func attachClusters(r *report.Report) {
 			NormSig:       g.NormSig,
 			Members:       append([]string(nil), g.Members...),
 		})
-	}
-
-	for i := range r.Tests {
-		if id, ok := keyToID[r.Tests[i].Fingerprint]; ok {
-			r.Tests[i].ClusterID = id
-		}
 	}
 	if len(out) > 0 {
 		r.Clusters = out


### PR DESCRIPTION
## Summary

Two Gemini follow-ups from PR #281:

**fo-oq9** — `pkg/watch`: wrap `restore` in `sync.Once`; call `restore()` from the ctx-cancel goroutine *before* `f.Close()` so `term.Restore` always runs on an open fd.

**fo-juf** — `pkg/testjson`: `attachClusters` used `t.Fingerprint` as `cluster.Input.Key`, but `cluster.Run` dedupes by Key (last-write-wins). Retried failures with identical fingerprints collapsed to one input and got dropped as singletons. Switch to a unique per-test index key; map back via `keyToTestIdx` when stamping ClusterID. Regression test added.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (all packages green)
- [x] new `TestAttachClusters_RetriesWithSameFingerprintBothCount` passes