### PR TITLE
fix(suppress): active rule wins over earlier expired match (fo-sc7)

### DIFF
--- a/pkg/report/filter.go
+++ b/pkg/report/filter.go
@@ -28,28 +28,41 @@ func ApplyFilter(r *Report, rs *suppress.Ruleset, now time.Time) FilterStats {
 	expiredNotified := map[int]bool{}
 	kept := r.Findings[:0]
 	for _, f := range r.Findings {
-		idx := rs.Match(f.RuleID, f.File)
-		if idx < 0 {
-			kept = append(kept, f)
-			continue
-		}
-		rule := rs.Rules[idx]
-		if rule.Expired(now) {
-			kept = append(kept, f)
-			if !expiredNotified[idx] {
-				expiredNotified[idx] = true
-				until := ""
-				if rule.Until != nil {
-					until = rule.Until.Format("2006-01-02")
-				}
-				r.Notices = append(r.Notices, fmt.Sprintf(
-					"suppression for %s (line %d) expired %s; finding shown",
-					rule.RuleID, rule.Line, until))
+		activeIdx, expiredIdx := -1, -1
+		for i := range rs.Rules {
+			if !rs.Rules[i].Matches(f.RuleID, f.File) {
+				continue
 			}
+			if rs.Rules[i].Expired(now) {
+				if expiredIdx < 0 {
+					expiredIdx = i
+				}
+				continue
+			}
+			activeIdx = i
+			break
+		}
+		if activeIdx >= 0 {
+			stats.Total++
+			stats.PerRule[activeIdx]++
 			continue
 		}
-		stats.Total++
-		stats.PerRule[idx]++
+		if expiredIdx < 0 {
+			kept = append(kept, f)
+			continue
+		}
+		rule := rs.Rules[expiredIdx]
+		kept = append(kept, f)
+		if !expiredNotified[expiredIdx] {
+			expiredNotified[expiredIdx] = true
+			until := ""
+			if rule.Until != nil {
+				until = rule.Until.Format("2006-01-02")
+			}
+			r.Notices = append(r.Notices, fmt.Sprintf(
+				"suppression for %s (line %d) expired %s; finding shown",
+				rule.RuleID, rule.Line, until))
+		}
 	}
 	r.Findings = kept
 	r.Suppressed += stats.Total

--- a/pkg/report/filter.go
+++ b/pkg/report/filter.go
@@ -47,21 +47,13 @@ func ApplyFilter(r *Report, rs *suppress.Ruleset, now time.Time) FilterStats {
 			stats.PerRule[activeIdx]++
 			continue
 		}
-		if expiredIdx < 0 {
-			kept = append(kept, f)
-			continue
-		}
-		rule := rs.Rules[expiredIdx]
 		kept = append(kept, f)
-		if !expiredNotified[expiredIdx] {
+		if expiredIdx >= 0 && !expiredNotified[expiredIdx] {
 			expiredNotified[expiredIdx] = true
-			until := ""
-			if rule.Until != nil {
-				until = rule.Until.Format("2006-01-02")
-			}
+			rule := rs.Rules[expiredIdx]
 			r.Notices = append(r.Notices, fmt.Sprintf(
 				"suppression for %s (line %d) expired %s; finding shown",
-				rule.RuleID, rule.Line, until))
+				rule.RuleID, rule.Line, rule.Until.Format("2006-01-02")))
 		}
 	}
 	r.Findings = kept

--- a/pkg/report/filter_test.go
+++ b/pkg/report/filter_test.go
@@ -81,6 +81,30 @@ func TestApplyFilter_ExpiredRuleKeepsAndNotices(t *testing.T) {
 	}
 }
 
+func TestApplyFilter_ActiveRuleBeatsEarlierExpired(t *testing.T) {
+	r := &Report{
+		Findings: []Finding{
+			{RuleID: "SA1019", File: "pkg/a.go", Severity: SeverityWarning},
+		},
+	}
+	rs := suppress.NewRuleset([]suppress.Suppression{
+		{RuleID: "SA1019", Glob: "**", Until: mustDate("2025-01-01"), Line: 3},
+		{RuleID: "SA1019", Glob: "**", Line: 7},
+	})
+	now := time.Date(2026, 5, 16, 0, 0, 0, 0, time.UTC)
+	stats := ApplyFilter(r, rs, now)
+
+	if len(r.Findings) != 0 {
+		t.Errorf("active rule should suppress despite earlier expired: %+v", r.Findings)
+	}
+	if stats.Total != 1 || stats.PerRule[1] != 1 {
+		t.Errorf("expected active rule index 1 credited: stats=%+v", stats)
+	}
+	if len(r.Notices) != 0 {
+		t.Errorf("no notice when active rule wins: %v", r.Notices)
+	}
+}
+
 func TestApplyFilter_NoRulesetIsNoop(t *testing.T) {
 	r := &Report{
 		Findings: []Finding{{RuleID: "X", File: "a.go", Severity: SeverityWarning}},

--- a/pkg/suppress/match.go
+++ b/pkg/suppress/match.go
@@ -27,6 +27,11 @@ func (rs *Ruleset) Match(ruleID, path string) int {
 	return -1
 }
 
+// Matches reports whether s applies to (ruleID, path), ignoring expiry.
+func (s Suppression) Matches(ruleID, path string) bool {
+	return matchSuppression(s, ruleID, path)
+}
+
 func matchSuppression(s Suppression, ruleID, path string) bool {
 	if s.RuleID != ruleID {
 		return false


### PR DESCRIPTION
## Summary
- Bug from Gemini review on #280: `rs.Match` returned first matching rule. An expired rule preceding an active rule shadowed the active one, leaving the finding shown with a stale "expired" notice instead of being suppressed.
- `ApplyFilter` now scans all matching rules for each finding: any active match suppresses; expired-only emits the notice.

## Test plan
- [x] New test `TestApplyFilter_ActiveRuleBeatsEarlierExpired` covers shadow case
- [x] Existing filter + suppress tests pass
- [x] `go build ./... && go test ./...` clean

Closes fo-sc7.