### PR TITLE
chore(ci): PR↔beads Closes-trailer convention + PR template

### DIFF
--- a/.claude/rules/CLAUDE.md
+++ b/.claude/rules/CLAUDE.md
@@ -86,6 +86,7 @@ Addressable surface (fo-u15): every finding/test carries a short handle (`F-7a2`
 ## Dev Workflow
 
 ‡ **Batch small fixes → one PR.** Several small/independent fixes in flight → ONE branch, ONE PR, one commit per fix. Full `check`/CI fires once at the PR (+ once on merge to main), NOT once per fix — a PR-per-one-liner serializes the queue behind build time. Each fix stays its own commit (traceable); PR body lists them. Review reads per-commit. Bundle by session/theme; ✗ mix a risky change in with trivial ones (it drags the whole PR's review bar up). **Default: auto-batch** — ≥2 small fixes queued → roll them onto one PR without asking.
+‡ **PR ↔ beads.** Every PR body carries a `Closes:` trailer naming the beads it lands: `Closes: fo-abc, fo-def` (no bead → `Closes: none`). Squash-merge keeps the trailer in main's commit. On merge, close them with the landing ref: `bd close <ids> --reason "merged #<PR> (<sha>)"`. ✗ merge-then-forget — a bead whose code landed but stays open is a leak.
 
 ## Search Scope
 Skip: vendor, node_modules, build, .trash, dist, .git, .worktrees

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,16 @@
+<!-- Keep it terse. Most PRs are small batches; one commit per bead. -->
+
+## What
+
+<!-- one-line summary of the change -->
+
+## Beads
+
+Closes: <bead-ids, comma-separated — or "none">
+
+<!-- On merge, close them with the landing ref:
+     bd close <ids> --reason "merged #<PR> (<sha>)". See .claude/rules/CLAUDE.md (Dev Workflow). -->
+
+## Notes
+
+<!-- review pointers, risk, test/eval evidence -->


### PR DESCRIPTION
## What

Adds the PR↔beads convention (follow-up to #285): every PR body carries a `Closes:` trailer; a new PR template scaffolds it.

## Beads

Closes: none

## Notes

- `.claude/rules/CLAUDE.md` Dev Workflow: terse `Closes:` trailer rule + close-on-merge with ref (`bd close <ids> --reason "merged #<PR> (<sha>)"`), ✗ merge-then-forget.
- `docs/pull_request_template.md`: What / Beads (`Closes:`) / Notes. Adapted from trixi's; dropped `scripts/wt-land` (fo has none), points the comment at fo's CLAUDE.md.
- **Deviation:** placed the template under `docs/` not `.github/` — GitHub reads PR templates from `docs/` too, and fo's doc-governance pre-commit hook blocks markdown in `.github/`. This avoids a `--no-verify` bypass.