### PR TITLE
chore: PR template (docs/) with Beads/Closes field

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -8,9 +8,8 @@
 
 Closes: <bead-ids, comma-separated — or "none">
 
-<!-- On merge, close them with the landing ref:
-     bd close <ids> --reason "merged #<PR> (<sha>)". See .claude/rules/CLAUDE.md (Dev Workflow). -->
+<!-- On merge, close these: bd close <ids> --reason "merged #<PR> (<sha>)". See .claude/rules/CLAUDE.md. -->
 
 ## Notes
 
-<!-- review pointers, risk, test/eval evidence -->
+<!-- review pointers, risk, test evidence -->


### PR DESCRIPTION
Backfills the PR template missed when #285 merged before the addendum. At docs/ (GitHub-honored) since fo doc-governance disallows .github/*.md. Pairs with the Closes: rule in CLAUDE.md.

Closes: none