### PR TITLE
feat: tee unfiltered output to a sidecar log

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -53,4 +53,4 @@
 # - github.org
 # - github.repo
 
-sync.remote: "git+https://github.com/dkoosis/fo.git"
+# sync.remote: "git+https://github.com/dkoosis/fo.git"

--- a/cmd/fo/e2e_test.go
+++ b/cmd/fo/e2e_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -240,6 +241,15 @@ func TestE2E_LLMGoldens(t *testing.T) {
 	}
 }
 
+var fullLogNoticeRE = regexp.MustCompile(`(?m)^  full: .*$`)
+
+// redactFullLogNotice replaces the full-log notice's path (which lives
+// under t.TempDir() and so varies run to run) with a fixed placeholder,
+// so golden comparisons stay stable.
+func redactFullLogNotice(out []byte) []byte {
+	return fullLogNoticeRE.ReplaceAll(out, []byte("  full: <redacted>"))
+}
+
 // TestE2E_LLMDiffGolden verifies that the full LLM output — leaderboard then
 // NEW block — matches a checked-in golden when a prior state is present.
 // Run with UPDATE_LLM_DIFF_GOLDEN=1 to regenerate.
@@ -252,6 +262,7 @@ func TestE2E_LLMDiffGolden(t *testing.T) {
 	}
 
 	dir := t.TempDir()
+	t.Setenv("FO_STATE_DIR", dir)
 	stateFile := filepath.Join(dir, "fo-state.json")
 	if err := os.WriteFile(stateFile, []byte(priorState), 0o600); err != nil {
 		t.Fatalf("write state: %v", err)
@@ -271,6 +282,13 @@ func TestE2E_LLMDiffGolden(t *testing.T) {
 	if !bytes.Contains(out, []byte("\nNEW (")) {
 		t.Errorf("expected NEW block in diff output; got:\n%s", out)
 	}
+	if !bytes.Contains(out, []byte("full: ")) {
+		t.Errorf("expected full-log notice pointing at the unfiltered original; got:\n%s", out)
+	}
+
+	// The full-log path is under t.TempDir(), so it varies run to run —
+	// redact it to a fixed placeholder before comparing to the golden.
+	out = redactFullLogNotice(out)
 
 	goldenPath := fixturesRoot + "/golangci/issues-withdiff.llm.golden"
 	if os.Getenv("UPDATE_LLM_DIFF_GOLDEN") == "1" {

--- a/cmd/fo/main.go
+++ b/cmd/fo/main.go
@@ -299,6 +299,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 2
 	}
 
+	rawInput := input
 	if *asFlag != "" {
 		coerced, code := coerceAs(*asFlag, input, stderr)
 		if code != 0 {
@@ -345,7 +346,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 
 	applySuppress(r, suppressPath(), stderr)
-	recordFullLog(r, input, policy, stderr)
+	recordFullLog(r, rawInput, policy, stderr)
 
 	saveErr := attachDiff(r, *stateFile, policy, stderr)
 

--- a/cmd/fo/main.go
+++ b/cmd/fo/main.go
@@ -345,6 +345,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 
 	applySuppress(r, suppressPath(), stderr)
+	recordFullLog(r, input, policy, stderr)
 
 	saveErr := attachDiff(r, *stateFile, policy, stderr)
 

--- a/cmd/fo/state.go
+++ b/cmd/fo/state.go
@@ -61,6 +61,13 @@ func recordFullLog(r *report.Report, input []byte, policy statePolicy, stderr io
 	}
 	path, err := state.SaveFullLog(input)
 	if err != nil {
+		if errors.Is(err, state.ErrDurabilityDegraded) {
+			fmt.Fprintf(stderr, "fo: state: full log: warning: %v\n", err)
+			r.Notices = append(r.Notices, "full: "+path)
+			r.Notices = append(r.Notices,
+				fmt.Sprintf("full log: durability degraded (%v) — sidecar may revert under crash", err))
+			return
+		}
 		fmt.Fprintf(stderr, "fo: state: full log: %v\n", err)
 		r.Notices = append(r.Notices, fmt.Sprintf("full log: save failed (%v)", err))
 		return

--- a/cmd/fo/state.go
+++ b/cmd/fo/state.go
@@ -50,6 +50,24 @@ func attachDiff(r *report.Report, statePath string, policy statePolicy, stderr i
 	return nil
 }
 
+// recordFullLog tees the complete, unfiltered input to a sidecar log and
+// notes its path on r.Notices as "full: <path>" — so a reader looking at
+// fo's (possibly truncated) output can recover the original in one
+// command, per the rtk pattern. Best-effort: a write failure degrades to
+// a Notice, not a run failure, matching attachDiff/assignAndPersistIDs.
+func recordFullLog(r *report.Report, input []byte, policy statePolicy, stderr io.Writer) {
+	if policy == stateOff || r == nil {
+		return
+	}
+	path, err := state.SaveFullLog(input)
+	if err != nil {
+		fmt.Fprintf(stderr, "fo: state: full log: %v\n", err)
+		r.Notices = append(r.Notices, fmt.Sprintf("full log: save failed (%v)", err))
+		return
+	}
+	r.Notices = append(r.Notices, "full: "+path)
+}
+
 // assignAndPersistIDs assigns short handles (F-/T-) to the report and,
 // unless state is off, pins them across runs: it loads the prior findings
 // snapshot for handle stability, assigns, then writes the new snapshot for

--- a/cmd/fo/state_test.go
+++ b/cmd/fo/state_test.go
@@ -212,6 +212,29 @@ func TestRecordFullLog_StateOffSkips(t *testing.T) {
 	}
 }
 
+func TestRun_AsFlag_FullLogPreservesRawInput(t *testing.T) {
+	// --as coerces input for parsing (e.g. tally auto-wraps plain text),
+	// but the full-log sidecar must still capture what was actually piped
+	// in, not the coerced form fed to the parser (fo-w1f review).
+	dir := t.TempDir()
+	t.Setenv("FO_STATE_DIR", dir)
+
+	raw := "main.go:10:2: unused variable x\n"
+	var stdout, stderr bytes.Buffer
+	code := run([]string{flagFormat, "json", "--as", "diag"}, strings.NewReader(raw), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d, stderr=%q", code, stderr.String())
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "full.log"))
+	if err != nil {
+		t.Fatalf("ReadFile(full.log): %v", err)
+	}
+	if string(got) != raw {
+		t.Errorf("full.log = %q, want raw pre-coercion input %q", got, raw)
+	}
+}
+
 func TestRecordFullLog_WriteFailureRecordsNotice(t *testing.T) {
 	dir := t.TempDir()
 	blocker := filepath.Join(dir, "not-a-dir")

--- a/cmd/fo/state_test.go
+++ b/cmd/fo/state_test.go
@@ -177,6 +177,61 @@ func TestWriteDiffDetail_FingerprintMiss_Fallback(t *testing.T) {
 	}
 }
 
+func TestRecordFullLog_AppendsFullNotice(t *testing.T) {
+	t.Setenv("FO_STATE_DIR", t.TempDir())
+
+	r := &report.Report{}
+	var stderr bytes.Buffer
+	recordFullLog(r, []byte("the complete original output"), stateOn, &stderr)
+
+	if len(r.Notices) != 1 {
+		t.Fatalf("expected one notice, got %v", r.Notices)
+	}
+	if !strings.HasPrefix(r.Notices[0], "full: ") {
+		t.Errorf("notice should start with %q, got %q", "full: ", r.Notices[0])
+	}
+	path := strings.TrimPrefix(r.Notices[0], "full: ")
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", path, err)
+	}
+	if string(got) != "the complete original output" {
+		t.Errorf("logged content = %q, want the full unfiltered input", got)
+	}
+}
+
+func TestRecordFullLog_StateOffSkips(t *testing.T) {
+	t.Setenv("FO_STATE_DIR", t.TempDir())
+
+	r := &report.Report{}
+	var stderr bytes.Buffer
+	recordFullLog(r, []byte("data"), stateOff, &stderr)
+
+	if len(r.Notices) != 0 {
+		t.Fatalf("expected no notice with state off, got %v", r.Notices)
+	}
+}
+
+func TestRecordFullLog_WriteFailureRecordsNotice(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("FO_STATE_DIR", filepath.Join(blocker, "sub"))
+
+	r := &report.Report{}
+	var stderr bytes.Buffer
+	recordFullLog(r, []byte("data"), stateOn, &stderr)
+
+	if len(r.Notices) != 1 {
+		t.Fatalf("expected one notice, got %v", r.Notices)
+	}
+	if !strings.Contains(r.Notices[0], "save failed") {
+		t.Errorf("notice should describe the save failure, got %q", r.Notices[0])
+	}
+}
+
 func TestAttachDiff_SaveFailureRecordsNoticeAndReturnsErr(t *testing.T) {
 	// Point state-file at a path whose parent cannot be created
 	// (mkdir under a regular file → ENOTDIR). attachDiff must

--- a/pkg/state/fulllog.go
+++ b/pkg/state/fulllog.go
@@ -1,0 +1,63 @@
+package state
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// FullLogPath returns the resolved path for the tee'd full-output log.
+// Single most-recent file, matching last-run.json's "one snapshot" shape
+// rather than run-log.json's append history — the log exists to make the
+// immediately preceding run's unfiltered output one command away, not to
+// build a history.
+func FullLogPath() string { return filepath.Join(Dir(), "full.log") }
+
+// SaveFullLog durably writes data (the complete, unfiltered original
+// input) to FullLogPath, overwriting any prior log. Returns the resolved
+// path so the caller can point the reader at it.
+func SaveFullLog(data []byte) (string, error) {
+	path := FullLogPath()
+	if err := writeAtomicBytes(path, ".full.*.tmp", data); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// writeAtomicBytes mirrors writeAtomic's durable-write shape (tempfile,
+// fsync, rename, parent-dir sync) for raw bytes instead of JSON.
+func writeAtomicBytes(path, tmpPattern string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("state: mkdir %s: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, tmpPattern)
+	if err != nil {
+		return fmt.Errorf("state: tempfile: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpName) }
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("state: write: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("state: fsync: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("state: close tmp: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		cleanup()
+		return fmt.Errorf("state: rename: %w", err)
+	}
+	if err := syncDir(filepath.Dir(path)); err != nil {
+		return fmt.Errorf("%w: %w", ErrDurabilityDegraded, err)
+	}
+	return nil
+}

--- a/pkg/state/fulllog.go
+++ b/pkg/state/fulllog.go
@@ -1,8 +1,8 @@
 package state
 
 import (
-	"fmt"
-	"os"
+	"errors"
+	"io"
 	"path/filepath"
 )
 
@@ -15,49 +15,17 @@ func FullLogPath() string { return filepath.Join(Dir(), "full.log") }
 
 // SaveFullLog durably writes data (the complete, unfiltered original
 // input) to FullLogPath, overwriting any prior log. Returns the resolved
-// path so the caller can point the reader at it.
+// path so the caller can point the reader at it — even under
+// ErrDurabilityDegraded, where the rename already landed the data on
+// disk and only the parent-dir fsync failed.
 func SaveFullLog(data []byte) (string, error) {
 	path := FullLogPath()
-	if err := writeAtomicBytes(path, ".full.*.tmp", data); err != nil {
+	err := writeAtomicTo(path, ".full.*.tmp", func(w io.Writer) error {
+		_, werr := w.Write(data)
+		return werr
+	})
+	if err != nil && !errors.Is(err, ErrDurabilityDegraded) {
 		return "", err
 	}
-	return path, nil
-}
-
-// writeAtomicBytes mirrors writeAtomic's durable-write shape (tempfile,
-// fsync, rename, parent-dir sync) for raw bytes instead of JSON.
-func writeAtomicBytes(path, tmpPattern string, data []byte) error {
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o750); err != nil {
-		return fmt.Errorf("state: mkdir %s: %w", dir, err)
-	}
-	tmp, err := os.CreateTemp(dir, tmpPattern)
-	if err != nil {
-		return fmt.Errorf("state: tempfile: %w", err)
-	}
-	tmpName := tmp.Name()
-	cleanup := func() { _ = os.Remove(tmpName) }
-
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		cleanup()
-		return fmt.Errorf("state: write: %w", err)
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		cleanup()
-		return fmt.Errorf("state: fsync: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		cleanup()
-		return fmt.Errorf("state: close tmp: %w", err)
-	}
-	if err := os.Rename(tmpName, path); err != nil {
-		cleanup()
-		return fmt.Errorf("state: rename: %w", err)
-	}
-	if err := syncDir(filepath.Dir(path)); err != nil {
-		return fmt.Errorf("%w: %w", ErrDurabilityDegraded, err)
-	}
-	return nil
+	return path, err
 }

--- a/pkg/state/fulllog_test.go
+++ b/pkg/state/fulllog_test.go
@@ -1,0 +1,60 @@
+package state
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveFullLog_WritesCompleteInput(t *testing.T) {
+	t.Setenv("FO_STATE_DIR", t.TempDir())
+
+	data := []byte("the complete unfiltered original\nline two\n")
+	path, err := SaveFullLog(data)
+	if err != nil {
+		t.Fatalf("SaveFullLog: %v", err)
+	}
+	if path != FullLogPath() {
+		t.Fatalf("path = %q, want %q", path, FullLogPath())
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("log content = %q, want %q", got, data)
+	}
+}
+
+func TestSaveFullLog_OverwritesPriorLog(t *testing.T) {
+	t.Setenv("FO_STATE_DIR", t.TempDir())
+
+	if _, err := SaveFullLog([]byte("first run")); err != nil {
+		t.Fatalf("SaveFullLog (first): %v", err)
+	}
+	path, err := SaveFullLog([]byte("second run"))
+	if err != nil {
+		t.Fatalf("SaveFullLog (second): %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "second run" {
+		t.Fatalf("log content = %q, want single most-recent run only", got)
+	}
+}
+
+func TestSaveFullLog_MkdirFailureReturnsErr(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("FO_STATE_DIR", filepath.Join(blocker, "sub"))
+
+	if _, err := SaveFullLog([]byte("data")); err == nil {
+		t.Fatalf("expected error when state dir cannot be created")
+	}
+}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -144,11 +145,20 @@ func Save(path string, f *File) error {
 	return writeAtomic(path, ".last-run.*.tmp", f)
 }
 
-// writeAtomic encodes v as indented JSON to a temp file in path's
-// directory, fsyncs it, then renames over path. tmpPattern is passed to
+// writeAtomic encodes v as indented JSON via writeAtomicTo.
+func writeAtomic(path, tmpPattern string, v any) error {
+	return writeAtomicTo(path, tmpPattern, func(w io.Writer) error {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(v)
+	})
+}
+
+// writeAtomicTo writes content to a temp file in path's directory via
+// write, fsyncs it, then renames over path. tmpPattern is passed to
 // os.CreateTemp. On parent-directory fsync failure it returns an error
 // wrapping ErrDurabilityDegraded (data is on disk; durability reduced).
-func writeAtomic(path, tmpPattern string, v any) error {
+func writeAtomicTo(path, tmpPattern string, write func(io.Writer) error) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return fmt.Errorf("state: mkdir %s: %w", dir, err)
@@ -160,12 +170,10 @@ func writeAtomic(path, tmpPattern string, v any) error {
 	tmpName := tmp.Name()
 	cleanup := func() { _ = os.Remove(tmpName) }
 
-	enc := json.NewEncoder(tmp)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(v); err != nil {
+	if err := write(tmp); err != nil {
 		_ = tmp.Close()
 		cleanup()
-		return fmt.Errorf("state: encode: %w", err)
+		return fmt.Errorf("state: write: %w", err)
 	}
 	if err := tmp.Sync(); err != nil {
 		_ = tmp.Close()

--- a/testdata/golden/v2/golangci/issues-withdiff.llm.golden
+++ b/testdata/golden/v2/golangci/issues-withdiff.llm.golden
@@ -238,3 +238,6 @@ NEW (112)
   fo/section_render_test.go:275  testifylint  error-nil: use assert.NoError
   fo/section_render_test.go:317  testifylint  error-nil: use assert.Error
   pkg/sarif/orchestrator.go:224  unused  field spinners is unused
+
+NOTICES (1)
+  full: <redacted>


### PR DESCRIPTION
## Summary
- Batch runs tee the complete raw input to `.fo/full.log` (single most-recent, mirrors `last-run.json`'s snapshot convention).
- LLM output gets a `full: <path>` NOTICES line so a reader looking at fo's filtered/truncated output can recover the original in one command — the rtk pattern from the 2026-07-26 session review.
- Best-effort: write failure degrades to a Notice, not a run failure (matches `attachDiff`/`assignAndPersistIDs`).
- Gated on `--no-state` (policy `stateOff`), same as other sidecars.

## Test plan
- [x] `make check` (vet, lint, full test suite, build) — clean
- [x] Golden `TestE2E_LLMDiffGolden` updated; volatile temp-dir path redacted before comparison
- [x] Manual smoke: `FO_STATE_DIR=/tmp/... fo --format llm < sarif` → NOTICES shows `full: /tmp/.../full.log`, log contains complete raw input

Closes: fo-w1f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable capture of complete, unfiltered run output.
  * Reports now include a link to the saved full-output log when state persistence is enabled.
  * Log-save failures are surfaced as notices without interrupting processing.

* **Bug Fixes**
  * Stabilized end-to-end output comparisons by masking temporary log paths.

* **Configuration**
  * Sync remote selection is no longer fixed by default and can be provided through other configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->