### PR TITLE
chore(lint): fo-92b adopt shared gorules bug-class pack (ccp-sbp)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,3 +36,10 @@ jobs:
 
       - name: build
         run: go build ./...
+
+      # bugclasses pack drift (ccp-sbp): fail if .golangci-rules/bugclasses.go
+      # has drifted from upstream. Network-soft — skips cleanly when upstream is
+      # unreachable (cc-plugins is private; activates once a token or public URL
+      # is wired via PACK_UPSTREAM_URL).
+      - name: pack-drift
+        run: make pack-drift

--- a/.golangci-rules/bugclasses.go
+++ b/.golangci-rules/bugclasses.go
@@ -1,0 +1,117 @@
+// Package gorules is a ruleguard bundle: machine-checkable rules for the
+// recurring Go defect classes surfaced by the 9-repo cross-repo scan
+// (decision nug d7ea466a8172). Each rule traces to real, verbatim-repeated
+// defects and runs inside golangci-lint's gocritic ruleguard checker. See
+// README.md for enablement, per-rule provenance, and the escape hatch.
+//
+// This file is DSL, not a program: ruleguard parses it, `go build` never
+// compiles it. It still lives in a real module so editor tooling and the
+// analysistest harness (rules_test.go) work.
+//
+// Rule coverage lives across three surfaces because no single golangci
+// mechanism spans them:
+//   - ruleguard (this file): scanner-buffer, raw-state-write, err-substring,
+//     pid-liveness.
+//   - forbidigo (see golangci.snippet.yml): context.Background in daemons.
+//   - a standalone analyzer (../omitemptyscalar): omitempty on meaningful
+//     zero-value fields — ruleguard can't read struct tags (README §rule 3).
+//
+// A consuming repo copies this file to .golangci-rules/bugclasses.go verbatim.
+// That copy drifts silently when the pack changes, so the pack is versioned:
+// bump the token below on ANY rule edit; each repo runs check-pack-drift.sh in
+// CI to compare its copy's hash against upstream (golangci.snippet.yml §drift).
+//
+//pack:version v1
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+// Bundle is the ruleguard bundle handle. It exists for the standalone
+// `ruleguard` binary, which can dsl.ImportRules() this pack from the module
+// cache and skip the file copy.
+//
+// It does NOT work under golangci-lint (the surface every consuming repo
+// actually runs). golangci-lint's embedded gocritic/ruleguard typechecks rule
+// files with a GOPATH-only source importer — it ignores go.mod, replace
+// directives, the module cache, and vendor/. A downstream file that imports
+// this package by module path fails ruleguard init with "cannot find package
+// ... (from $GOROOT)/(from $GOPATH)". Verified against golangci-lint v2.12.2 /
+// ruleguard dsl v0.3.22 (spike, 2026-08-04). So consuming repos MUST copy the
+// rule file and drift-check the copy — see check-pack-drift.sh. Do not wire an
+// ImportRules shim expecting golangci-lint to resolve it.
+var Bundle = dsl.Bundle{}
+
+// --- Rule 1: bufio.Scanner with the default 64KB token cap ------------------
+
+//doc:summary bufio.NewScanner consumed without a Buffer() cap override
+//doc:before  sc := bufio.NewScanner(r); for sc.Scan() { ... }
+//doc:after   sc := bufio.NewScanner(r); sc.Buffer(buf, max); for sc.Scan() { ... }
+//doc:tags    correctness
+func scannerDefaultBuffer(m dsl.Matcher) {
+	// The defect shape: a scanner is created and consumed with the scan loop
+	// adjacent to the constructor. A Buffer() call sits BETWEEN the two lines
+	// in fixed code, breaking statement adjacency, so this stays silent once
+	// the cap is set. Heuristic, not flow analysis — README §rule 1.
+	m.Match(
+		`$sc := bufio.NewScanner($r)
+		 for $sc.Scan() { $*_ }`,
+	).
+		// Skip tests (fixtures aren't production input) and in-memory readers
+		// (strings/bytes.NewReader is bounded by an already-loaded value —
+		// the same carve-out the alloc-bounds lens makes for ReadAll).
+		Where(!m.File().Name.Matches(`_test\.go$`) &&
+			!m["r"].Text.Matches(`^(strings|bytes)\.NewReader`)).
+		Report(`bufio.Scanner default 64KB token cap truncates long input; call $sc.Buffer(buf, max)`)
+}
+
+// Rule 2 (raw durable-state write) lives in optin_rawstatewrite.go — it ships
+// OFF, so it is a separate file the `rules` glob includes only once a repo
+// adopts atomicfile. gocritic's ruleguard checker exposes no per-group
+// disable, so file selection is the toggle (README §enablement).
+
+// --- Rule 4: error classification by substring ------------------------------
+
+//doc:summary error classified by matching err.Error() text
+//doc:before  strings.Contains(err.Error(), "not found")
+//doc:after   errors.Is(err, ErrNotFound)
+//doc:tags    correctness
+func errSubstringMatch(m dsl.Matcher) {
+	// strings.Contains / HasPrefix / HasSuffix over an .Error() string.
+	// Test files legitimately assert on error text; the defect is production
+	// control flow keyed on a message. Exclude _test.go from both groups.
+	m.Match(
+		`strings.Contains($err.Error(), $_)`,
+		`strings.HasPrefix($err.Error(), $_)`,
+		`strings.HasSuffix($err.Error(), $_)`,
+	).
+		Where(m["err"].Type.Implements(`error`) &&
+			!m.File().Name.Matches(`_test\.go$`)).
+		Report(`error classified by substring; use typed sentinels + errors.Is/As`)
+
+	// Direct equality/inequality of an error's message to a constant.
+	m.Match(
+		`$err.Error() == $s`,
+		`$err.Error() != $s`,
+		`$s == $err.Error()`,
+		`$s != $err.Error()`,
+	).
+		Where(m["err"].Type.Implements(`error`) && m["s"].Const &&
+			!m.File().Name.Matches(`_test\.go$`)).
+		Report(`error compared by message text; use errors.Is with a sentinel`)
+}
+
+// --- Rule 6: PID-only liveness check ----------------------------------------
+
+//doc:summary liveness probed by signalling a PID with no start-time witness
+//doc:before  proc.Signal(syscall.Signal(0))
+//doc:after   witness process start-time (PID reuse gives a false positive)
+//doc:tags    correctness
+func pidLivenessSignal(m dsl.Matcher) {
+	// Signal(0) on an *os.Process is the textbook PID-liveness probe; it says
+	// nothing about PID reuse. Narrow — the zero-signal idiom is rare outside
+	// this check, so it does not fire on real signalling.
+	m.Match(
+		`$p.Signal(syscall.Signal(0))`,
+	).
+		Report(`PID-only liveness: reused PID gives a false positive; witness proc start-time`)
+}

--- a/.golangci-rules/check-pack-drift.sh
+++ b/.golangci-rules/check-pack-drift.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# check-pack-drift.sh — fail CI when a consuming repo's copied bugclasses rules
+# have drifted from the upstream cc-plugins pack.
+#
+# The pack ships as a copied file (.golangci-rules/bugclasses.go, a verbatim
+# copy of gorules/rules.go). Copies rot silently: upstream fixes a rule, the
+# copy stays stale, or someone hand-edits the copy. This makes both loud.
+#
+# It compares two things:
+#   1. version token — the //pack:version line in the local copy vs upstream.
+#   2. content hash  — sha256 of the local copy vs upstream rules.go (catches
+#      local edits that DIDN'T bump the version).
+#
+# Vendor this into the consuming repo (e.g. .golangci-rules/) and run it in CI
+# after golangci-lint. Network-soft: an unreachable upstream WARNS and exits 0
+# so a transient outage never breaks the build; a real mismatch exits 1.
+#
+# Usage: check-pack-drift.sh [path-to-local-bugclasses.go]
+#   default local path: .golangci-rules/bugclasses.go
+set -euo pipefail
+
+UPSTREAM_URL="${PACK_UPSTREAM_URL:-https://raw.githubusercontent.com/dkoosis/cc-plugins/main/plugins/lintbrush/gorules/rules.go}"
+LOCAL="${1:-.golangci-rules/bugclasses.go}"
+
+die()  { printf '✗ pack-drift: %s\n' "$*" >&2; exit 1; }
+warn() { printf '⚠ pack-drift: %s\n' "$*" >&2; }
+
+[[ -f "$LOCAL" ]] || die "local copy not found: $LOCAL"
+
+sha()  { shasum -a 256 "$1" 2>/dev/null | awk '{print $1}'; }
+vtok() { grep -m1 '//pack:version' "$1" 2>/dev/null | awk '{print $2}'; }
+
+upstream="$(mktemp)"
+trap 'rm -f "$upstream"' EXIT
+if ! curl -fsSL --max-time 10 "$UPSTREAM_URL" -o "$upstream" 2>/dev/null; then
+	warn "upstream unreachable ($UPSTREAM_URL) — skipping drift check"
+	exit 0
+fi
+
+lv="$(vtok "$LOCAL")"; uv="$(vtok "$upstream")"
+lh="$(sha "$LOCAL")";  uh="$(sha "$upstream")"
+
+if [[ "$lh" == "$uh" ]]; then
+	printf '✓ pack-drift: in sync (%s)\n' "${lv:-unversioned}"
+	exit 0
+fi
+
+if [[ "$lv" != "$uv" ]]; then
+	die "version drift: local ${lv:-none} vs upstream ${uv:-none}. Re-copy rules.go → $LOCAL and re-tune exclusions."
+fi
+die "content drift: $LOCAL differs from upstream at the same version ($lv). A local hand-edit? Re-copy or bump upstream."

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
     # Safety
     - bodyclose
     - containedctx
+    - forbidigo
     - forcetypeassert
     - gosec
     - noctx
@@ -102,6 +103,21 @@ linters:
       enabled-tags:
         - diagnostic
         - performance
+      # bugclasses pack (ccp-sbp, decision nug d7ea466a8172): the ruleguard
+      # checker runs the shared machine rules for the recurring cross-repo Go
+      # defect classes. Rules live in .golangci-rules/bugclasses.go — a verbatim
+      # copy of the upstream pack, drift-guarded by
+      # .golangci-rules/check-pack-drift.sh (make pack-drift).
+      enabled-checks:
+        - ruleguard
+      settings:
+        ruleguard:
+          # ${base-path} = the .golangci.yml directory (golangci-lint v2). The
+          # glob names ONLY bugclasses.go, so rule 2 (raw-state-write, the
+          # opt-in file) stays off until fo moves durable state to atomicfile.
+          rules: "${base-path}/.golangci-rules/bugclasses.go"
+          # Fail the run on rule-compile errors — never silently skip them.
+          failOn: dsl
       disabled-checks:
         - appendCombine
         - commentFormatting
@@ -109,6 +125,17 @@ linters:
         - hugeParam
         - ifElseChain
         - unlambda
+    forbidigo:
+      # bugclasses rule 5: context.Background() deep in daemon/long-lived code
+      # should thread the caller/shutdown ctx (strand st-47z, trixi #606,
+      # trixi-bot gg-8rq.3, canapay can-x38). Path-scoped below to fo's
+      # long-lived paths (watch/stream); noise everywhere else, so the
+      # exclusions rule carves out the CLI entrypoint, cmd wiring, and tests.
+      # Types-aware so a `ctx.Background` field can't false-fire.
+      analyze-types: true
+      forbid:
+        - pattern: '^context\.Background$'
+          msg: "thread the caller/shutdown ctx; context.Background belongs only at a daemon's root (main/startup)"
     cyclop:
       max-complexity: 15
     funlen:
@@ -201,6 +228,13 @@ linters:
       # Comment dupword (e.g. "the the" inside doc lines from prose)
       - linters: [dupword]
         source: "^\\s*//"
+      # bugclasses rule 5 (forbidigo Background ban): context.Background is
+      # legitimate at fo's CLI root (cmd/fo), in main.go, and in tests. fo is a
+      # formatting CLI, not a daemon; the ban only bites long-lived paths where
+      # a fresh root context would sever cancellation.
+      - linters: [forbidigo]
+        path: '(_test\.go$|(^|/)cmd/|(^|/)main\.go$)'
+        text: 'context\.Background'
     paths:
       - third_party$
       - examples$

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 .DEFAULT_GOAL := check
 
 .PHONY: help scan check audit audit-human audit-llm report deploy install build doctor cross \
-        vet lint test race fmt fmt-fix dupl vuln \
+        vet lint test race fmt fmt-fix dupl vuln pack-drift \
         qa-goldens qa-goldens-update \
         snipe-index baseline \
         cross-amd64 cross-arm64 \
@@ -56,7 +56,7 @@ help: ## Show this help
 		/^## [^-]/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 4) } \
 		/^[a-zA-Z0-9_-]+:.*?## / { printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
-check: vet lint test build ## Full repo: vet + lint + test + build
+check: vet lint test build pack-drift ## Full repo: vet + lint + test + build + pack-drift
 	@echo "=== check pass ==="
 
 audit: snipe-index ## Exhaustive stream through fo (auto: human@TTY, llm piped)
@@ -138,6 +138,9 @@ dupl: ## Check for code duplication (jscpd)
 
 vuln: ## Scan for known vulnerabilities
 	govulncheck ./...
+
+pack-drift: ## Fail if the copied bugclasses rules drifted from upstream (network-soft)
+	@.golangci-rules/check-pack-drift.sh .golangci-rules/bugclasses.go
 
 lint-sarif: vet ## Run linters with SARIF output
 	golangci-lint run --output.sarif.path=stdout ./...

--- a/cmd/fo/fswatch.go
+++ b/cmd/fo/fswatch.go
@@ -42,6 +42,7 @@ func loadGitignorePatterns(root string) []string {
 	}
 	defer func() { _ = f.Close() }()
 	var pats []string
+	//nolint:gocritic // bugclasses rule 1: .gitignore lines are short patterns, never near the 64KB default token cap; no Buffer() cap needed.
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {
 		line := strings.TrimSpace(sc.Text())

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/muesli/termenv v0.16.0
+	github.com/quasilyte/go-ruleguard/dsl v0.3.23
 	github.com/rogpeppe/go-internal v1.14.1
 	golang.org/x/term v0.37.0
 )

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byF
 github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
+github.com/quasilyte/go-ruleguard/dsl v0.3.23 h1:lxjt5B6ZCiBeeNO8/oQsegE6fLeCzuMRoVWSkXC4uvY=
+github.com/quasilyte/go-ruleguard/dsl v0.3.23/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,15 @@
+//go:build tools
+
+// Package tools pins build-only tool dependencies into the module graph so
+// `go mod tidy` keeps them, without letting them enter the fo binary.
+//
+// The lone entry is the ruleguard DSL: .golangci-rules/bugclasses.go (the
+// shared bugclasses pack, ccp-sbp) imports it, but that file lives in a
+// dot-directory the Go toolchain ignores — so tidy never sees the import and
+// would drop dsl from go.mod, leaving golangci-lint's embedded ruleguard unable
+// to typecheck the rules file (its importer resolves only from the module
+// graph, not $GOROOT/$GOPATH). This blank import is the bridge. The `tools`
+// build tag keeps the file out of every normal build.
+package tools
+
+import _ "github.com/quasilyte/go-ruleguard/dsl"


### PR DESCRIPTION
Adopts the shared lintbrush **bugclasses** ruleguard pack into fo (decision nug `d7ea466a8172`). Machine rules for the recurring cross-repo Go defect classes, drift-guarded against upstream.

## Scope — pack rules only
Rules **1** (scanner default buffer), **4** (err-substring match), **5** (context.Background in daemon), **6** (PID-only liveness). Rule 2 (raw-state-write) stays **off** (glob names only `bugclasses.go`); rule 3 (omitempty-scalar) not adopted. No baseline-floor changes.

## Changes
- **`.golangci-rules/bugclasses.go`** — verbatim copy of upstream `rules.go` (`//pack:version v1`, sha256 `c66d108…`).
- **`.golangci-rules/check-pack-drift.sh`** — vendored drift guard (network-soft: warns + exits 0 when upstream unreachable; cc-plugins is private).
- **`tools.go`** — build-tagged blank import of `go-ruleguard/dsl` so `go mod tidy` keeps it in the module graph (dsl `v0.3.23`). Without it, golangci's embedded ruleguard can't typecheck the rules file.
- **`.golangci.yml`** (v2) — enable `gocritic` `ruleguard` (`failOn: dsl`) + `forbidigo` (types-aware `context.Background` ban). Ban path-scoped away from `cmd/` (CLI root), `main.go`, and tests — tuned to fo's `cmd/fo` layout.
- **`Makefile`** — `pack-drift` target wired into `check`.
- **CI** — network-soft `pack-drift` step.

## FP audit (golangci-lint 2.12.2)
4 hits, all resolved; matches the pack's audit prediction (fo: 1 scanner):
| Site | Rule | Resolution |
|------|------|-----------|
| `cmd/fo/fswatch.go:45` | 1 scanner | `//nolint:gocritic` — reads `.gitignore`; short pattern lines, never near the 64KB cap. |
| `cmd/fo/stream.go:53,179`, `cmd/fo/watch.go:100` | 5 forbidigo | Correct-by-design `signal.NotifyContext(context.Background(), …)` at the CLI command root — scoped out via the `(^\|/)cmd/` path exclusion (the starter `/cmd/` regex needed a non-leading-slash anchor for fo's layout). |

No blanket ignores. Gate green: `vet` + `lint` (0 issues) + `test` + `build` + `pack-drift`.

Bead: fo-92b.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated checks for unsafe scanner usage, fragile error classification, and unreliable process liveness checks.
  - Added enforcement against inappropriate background context usage, with approved exceptions.

- **Bug Fixes**
  - Added validation to detect drift between local and upstream analysis rules.

- **Chores**
  - Integrated the new validations into the standard project checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->